### PR TITLE
line formatter fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
   "prefer-stable": true,
   "require": {
     "php": "^8.2",
-    "bramus/monolog-colored-line-formatter": "~3.0.0|~3.1.0",
     "monolog/monolog": "^2.0|^3.0",
     "laravel/framework": "^8.0|^9.0|^10.0",
     "sentry/sentry-laravel": "^4.11"

--- a/src/Logging/ColoredJsonLineFormatter.php
+++ b/src/Logging/ColoredJsonLineFormatter.php
@@ -2,19 +2,15 @@
 
 namespace Nuimarkets\LaravelSharedUtils\Logging;
 
-use Bramus\Monolog\Formatter\ColoredLineFormatter;
 use JsonSerializable;
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Logger;
-
-// Compatibility check for Monolog 3.x LogRecord
-if (class_exists('Monolog\LogRecord')) {
-    use Monolog\LogRecord;
-}
 
 /**
  * Formats log records as colored JSON lines with improved readability.
+ * Compatible with both Monolog 2.x and 3.x.
  */
-class ColoredJsonLineFormatter extends ColoredLineFormatter
+class ColoredJsonLineFormatter implements FormatterInterface
 {
     private const HEADER_FORMAT = "%-32s %-10s %s\n";
 
@@ -24,12 +20,35 @@ class ColoredJsonLineFormatter extends ColoredLineFormatter
 
     private const KEY_PADDING = 20;
 
+    // ANSI color codes for different log levels
+    private const COLOR_SCHEME = [
+        Logger::DEBUG => "\033[0;37m",     // Light gray
+        Logger::INFO => "\033[0;32m",      // Green
+        Logger::NOTICE => "\033[0;36m",    // Cyan
+        Logger::WARNING => "\033[0;33m",   // Yellow
+        Logger::ERROR => "\033[0;31m",     // Red
+        Logger::CRITICAL => "\033[1;31m",  // Bold red
+        Logger::ALERT => "\033[1;35m",     // Bold magenta
+        Logger::EMERGENCY => "\033[1;31m", // Bold red
+    ];
+
+    private const COLOR_RESET = "\033[0m";
+
+    /**
+     * Whether colors are enabled for this formatter
+     */
+    private bool $colorsEnabled;
+
+    public function __construct(bool $colorsEnabled = true)
+    {
+        $this->colorsEnabled = $colorsEnabled;
+    }
+
     public function format($record): string
     {
         // Handle both Monolog 2.x (array) and 3.x (LogRecord) formats
         $isLogRecord = class_exists('Monolog\LogRecord') && $record instanceof \Monolog\LogRecord;
         
-        $colorScheme = $this->getColorScheme();
         $className = $this->extractClassName($record, $isLogRecord);
 
         // Extract data based on record type
@@ -47,18 +66,28 @@ class ColoredJsonLineFormatter extends ColoredLineFormatter
             $message,
         );
 
-        $output = $this->colorize($headerLine, $level, $colorScheme);
+        $output = $this->colorize($headerLine, $level);
 
         // Add context if present
         if (! empty($context)) {
-            $output .= $this->formatContext($context, $colorScheme);
+            $output .= $this->formatContext($context);
         }
 
         if (! empty($extra) && env('LOG_PRETTY_SHOW_EXTRA', false)) {
-            $output .= $this->formatContext($extra, $colorScheme);
+            $output .= $this->formatContext($extra);
         }
 
         return $output."\n";
+    }
+
+    public function formatBatch(array $records): string
+    {
+        $message = '';
+        foreach ($records as $record) {
+            $message .= $this->format($record);
+        }
+
+        return $message;
     }
 
     private function extractClassName($record, bool $isLogRecord = null): string
@@ -79,10 +108,10 @@ class ColoredJsonLineFormatter extends ColoredLineFormatter
         return str_replace(['Trait', 'Interface', 'Abstract'], '', $className);
     }
 
-    private function formatContext(array $context, object $colorScheme): string
+    private function formatContext(array $context): string
     {
-        $debugColor = $colorScheme->getColorizeString(Logger::WARNING);
-        $reset = $colorScheme->getResetString();
+        $debugColor = $this->getColorForLevel(Logger::WARNING);
+        $reset = self::COLOR_RESET;
 
         $dataTree = $this->formatDataAsTree($context, 1);
         $lines = explode("\n", $dataTree);
@@ -92,7 +121,9 @@ class ColoredJsonLineFormatter extends ColoredLineFormatter
                 $truncated = strlen($line) > self::MAX_LINE_LENGTH;
                 $truncatedLine = substr($line, 0, self::MAX_LINE_LENGTH - ($truncated ? 3 : 0));
 
-                return $debugColor.$truncatedLine.($truncated ? '...' : '').$reset;
+                return $this->colorsEnabled 
+                    ? $debugColor.$truncatedLine.($truncated ? '...' : '').$reset
+                    : $truncatedLine.($truncated ? '...' : '');
             },
             $lines,
         );
@@ -100,11 +131,20 @@ class ColoredJsonLineFormatter extends ColoredLineFormatter
         return implode("\n", $coloredLines)."\n";
     }
 
-    private function colorize(string $text, int $level, object $colorScheme): string
+    private function colorize(string $text, int $level): string
     {
-        return $colorScheme->getColorizeString($level).
+        if (!$this->colorsEnabled) {
+            return $text;
+        }
+
+        return $this->getColorForLevel($level).
             $text.
-            $colorScheme->getResetString();
+            self::COLOR_RESET;
+    }
+
+    private function getColorForLevel(int $level): string
+    {
+        return self::COLOR_SCHEME[$level] ?? self::COLOR_SCHEME[Logger::INFO];
     }
 
     protected function formatDataAsTree(mixed $data, int $indent = 0): string

--- a/tests/Unit/Logging/ColoredJsonLineFormatterTest.php
+++ b/tests/Unit/Logging/ColoredJsonLineFormatterTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Nuimarkets\LaravelSharedUtils\Tests\Unit\Logging;
+
+use Nuimarkets\LaravelSharedUtils\Logging\ColoredJsonLineFormatter;
+use Nuimarkets\LaravelSharedUtils\Tests\TestCase;
+use Monolog\Logger;
+
+class ColoredJsonLineFormatterTest extends TestCase
+{
+    private ColoredJsonLineFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->formatter = new ColoredJsonLineFormatter();
+    }
+
+    /** @test */
+    public function test_formats_monolog_2_array_record_correctly()
+    {
+        // Monolog 2.x array format
+        $record = [
+            'message' => 'Test message',
+            'context' => ['key' => 'value'],
+            'level' => Logger::INFO,
+            'level_name' => 'INFO',
+            'channel' => 'test',
+            'datetime' => new \DateTimeImmutable(),
+            'extra' => [
+                'source_file' => '/path/to/TestClass.php'
+            ],
+        ];
+
+        $output = $this->formatter->format($record);
+
+        $this->assertStringContainsString('TestClass', $output);
+        $this->assertStringContainsString('INFO', $output);
+        $this->assertStringContainsString('Test message', $output);
+        $this->assertStringContainsString('key', $output);
+        $this->assertStringContainsString('value', $output);
+    }
+
+    /** @test */
+    public function test_formats_monolog_3_log_record_correctly()
+    {
+        if (!class_exists('Monolog\LogRecord')) {
+            $this->markTestSkipped('Monolog 3 LogRecord class not available');
+        }
+
+        // Monolog 3.x LogRecord format
+        $record = new \Monolog\LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'test',
+            level: \Monolog\Level::Info,
+            message: 'Test message',
+            context: ['key' => 'value'],
+            extra: ['source_file' => '/path/to/TestClass.php']
+        );
+
+        $output = $this->formatter->format($record);
+
+        $this->assertStringContainsString('TestClass', $output);
+        $this->assertStringContainsString('INFO', $output);
+        $this->assertStringContainsString('Test message', $output);
+        $this->assertStringContainsString('key', $output);
+        $this->assertStringContainsString('value', $output);
+    }
+
+    /** @test */
+    public function test_handles_empty_context_gracefully()
+    {
+        $record = [
+            'message' => 'Test message',
+            'context' => [],
+            'level' => Logger::INFO,
+            'level_name' => 'INFO',
+            'channel' => 'test',
+            'datetime' => new \DateTimeImmutable(),
+            'extra' => [],
+        ];
+
+        $output = $this->formatter->format($record);
+
+        $this->assertStringContainsString('Test message', $output);
+        $this->assertStringContainsString('INFO', $output);
+        // Should not contain context formatting
+        $this->assertStringNotContainsString('key', $output);
+    }
+
+    /** @test */
+    public function test_extracts_class_name_from_source_file()
+    {
+        $record = [
+            'message' => 'Test message',
+            'context' => [],
+            'level' => Logger::INFO,
+            'level_name' => 'INFO',
+            'channel' => 'test',
+            'datetime' => new \DateTimeImmutable(),
+            'extra' => [
+                'source_file' => '/app/src/Services/UserServiceTrait.php'
+            ],
+        ];
+
+        $output = $this->formatter->format($record);
+
+        // Should extract 'UserService' (removing 'Trait' suffix)
+        $this->assertStringContainsString('UserService', $output);
+        $this->assertStringNotContainsString('UserServiceTrait', $output);
+    }
+
+    /** @test */
+    public function test_handles_missing_source_file()
+    {
+        $record = [
+            'message' => 'Test message',
+            'context' => [],
+            'level' => Logger::INFO,
+            'level_name' => 'INFO',
+            'channel' => 'test',
+            'datetime' => new \DateTimeImmutable(),
+            'extra' => [],
+        ];
+
+        $output = $this->formatter->format($record);
+
+        $this->assertStringContainsString('Test message', $output);
+        $this->assertStringContainsString('INFO', $output);
+        // Should handle gracefully without errors
+        $this->assertIsString($output);
+    }
+
+    /** @test */
+    public function test_formats_nested_context_data()
+    {
+        $record = [
+            'message' => 'Test message',
+            'context' => [
+                'user' => [
+                    'id' => 123,
+                    'name' => 'John Doe'
+                ],
+                'metadata' => [
+                    'action' => 'login',
+                    'ip' => '192.168.1.1'
+                ]
+            ],
+            'level' => Logger::INFO,
+            'level_name' => 'INFO',
+            'channel' => 'test',
+            'datetime' => new \DateTimeImmutable(),
+            'extra' => [],
+        ];
+
+        $output = $this->formatter->format($record);
+
+        $this->assertStringContainsString('user', $output);
+        $this->assertStringContainsString('123', $output);
+        $this->assertStringContainsString('John Doe', $output);
+        $this->assertStringContainsString('metadata', $output);
+        $this->assertStringContainsString('login', $output);
+        $this->assertStringContainsString('192.168.1.1', $output);
+    }
+
+    /** @test */
+    public function test_handles_different_log_levels()
+    {
+        $levels = [
+            ['level' => Logger::DEBUG, 'name' => 'DEBUG'],
+            ['level' => Logger::INFO, 'name' => 'INFO'],
+            ['level' => Logger::WARNING, 'name' => 'WARNING'],
+            ['level' => Logger::ERROR, 'name' => 'ERROR'],
+            ['level' => Logger::CRITICAL, 'name' => 'CRITICAL'],
+        ];
+
+        foreach ($levels as $levelData) {
+            $record = [
+                'message' => 'Test message',
+                'context' => [],
+                'level' => $levelData['level'],
+                'level_name' => $levelData['name'],
+                'channel' => 'test',
+                'datetime' => new \DateTimeImmutable(),
+                'extra' => [],
+            ];
+
+            $output = $this->formatter->format($record);
+
+            $this->assertStringContainsString($levelData['name'], $output);
+        }
+    }
+
+    /** @test */
+    public function test_removes_trait_interface_abstract_from_class_names()
+    {
+        $testCases = [
+            'UserTrait.php' => 'User',
+            'ServiceInterface.php' => 'Service',
+            'AbstractController.php' => 'Controller',
+            'RegularClass.php' => 'RegularClass',
+        ];
+
+        foreach ($testCases as $fileName => $expectedClassName) {
+            $record = [
+                'message' => 'Test message',
+                'context' => [],
+                'level' => Logger::INFO,
+                'level_name' => 'INFO',
+                'channel' => 'test',
+                'datetime' => new \DateTimeImmutable(),
+                'extra' => [
+                    'source_file' => "/app/src/{$fileName}"
+                ],
+            ];
+
+            $output = $this->formatter->format($record);
+            $this->assertStringContainsString($expectedClassName, $output);
+        }
+    }
+
+    /** @test */
+    public function test_output_contains_newline_termination()
+    {
+        $record = [
+            'message' => 'Test message',
+            'context' => [],
+            'level' => Logger::INFO,
+            'level_name' => 'INFO',
+            'channel' => 'test',
+            'datetime' => new \DateTimeImmutable(),
+            'extra' => [],
+        ];
+
+        $output = $this->formatter->format($record);
+
+        $this->assertStringEndsWith("\n", $output);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved compatibility with both Monolog 2.x and 3.x log formats, ensuring seamless logging regardless of the version in use.
  - Added option to enable or disable colored output in log formatting for better readability and customization.
- **Tests**
  - Introduced comprehensive tests covering multiple logging scenarios and Monolog versions to ensure reliable log formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->