### PR TITLE
limit stack trace depth

### DIFF
--- a/src/Logging/SourceLocationProcessor.php
+++ b/src/Logging/SourceLocationProcessor.php
@@ -5,7 +5,7 @@ namespace NuiMarkets\LaravelSharedUtils\Logging;
 /**
  * Log Processor for PHP Source Location
  * 
- * Generates debug trace information while preventing Elasticsearch field explosion
+ * Generates debug trace information while preventing field explosion in log storage
  * by limiting the number of frame fields created.
  * 
  * Compatible with both Monolog 2.x (array records) and 3.x (LogRecord objects)
@@ -23,7 +23,7 @@ class SourceLocationProcessor
      * Create a new SourceLocationProcessor
      * 
      * @param int $maxFrames Maximum frames to capture from backtrace (for source detection)
-     * @param int $outputFrames Maximum frame_N fields to output (for ES compatibility)
+     * @param int $outputFrames Maximum frame_N fields to output (for log storage compatibility)
      */
     public function __construct(int $maxFrames = 10, int $outputFrames = 3)
     {
@@ -43,7 +43,7 @@ class SourceLocationProcessor
         $isLogRecord = is_object($record);
         $extra = $isLogRecord ? $record->extra : ($record['extra'] ?? []);
         
-        // Limit backtrace to prevent ES field explosion and improve performance
+        // Limit backtrace to prevent field explosion and improve performance
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $this->maxFrames);
 
         $extra['debug_trace'] = 'Trace count: '.count($trace);

--- a/src/Logging/SourceLocationProcessor.php
+++ b/src/Logging/SourceLocationProcessor.php
@@ -45,13 +45,16 @@ class SourceLocationProcessor
         
         // Limit backtrace to prevent field explosion and improve performance
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $this->maxFrames);
+        
+        // Safe fallback for base_path() when used outside Laravel
+        $base = function_exists('base_path') ? base_path() : '';
 
         $extra['debug_trace'] = 'Trace count: '.count($trace);
 
         $debugFrames = array_slice($trace, 0, $this->outputFrames);
         foreach ($debugFrames as $index => $frame) {
             if (isset($frame['file'])) {
-                $extra['frame_'.$index] = str_replace(base_path(), '', $frame['file']);
+                $extra['frame_'.$index] = str_replace($base, '', $frame['file']);
             }
         }
 
@@ -67,7 +70,7 @@ class SourceLocationProcessor
         }
 
         if ($sourceFrame) {
-            $extra['source_file'] = str_replace(base_path(), '', $sourceFrame['file']);
+            $extra['source_file'] = str_replace($base, '', $sourceFrame['file']);
             $extra['source_line'] = $sourceFrame['line'];
         }
 

--- a/tests/Unit/SourceLocationProcessorTest.php
+++ b/tests/Unit/SourceLocationProcessorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit;
+
+use NuiMarkets\LaravelSharedUtils\Logging\SourceLocationProcessor;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+class SourceLocationProcessorTest extends TestCase
+{
+    public function test_limits_frame_fields_to_prevent_es_explosion()
+    {
+        // Create processor with custom limits
+        $processor = new SourceLocationProcessor(maxFrames: 5, outputFrames: 2);
+        
+        $record = [
+            'message' => 'Test log message',
+            'level' => 200,
+            'extra' => []
+        ];
+        
+        $result = $processor($record);
+        
+        // Should have debug_trace
+        $this->assertArrayHasKey('debug_trace', $result['extra']);
+        $this->assertStringContainsString('Trace count:', $result['extra']['debug_trace']);
+        
+        // Should only have limited frame fields
+        $frameKeys = array_filter(array_keys($result['extra']), fn($key) => str_starts_with($key, 'frame_'));
+        $this->assertLessThanOrEqual(2, count($frameKeys), 'Should not exceed outputFrames limit');
+        
+        // Check frame fields are properly numbered
+        $this->assertArrayHasKey('frame_0', $result['extra']);
+        if (count($frameKeys) > 1) {
+            $this->assertArrayHasKey('frame_1', $result['extra']);
+        }
+        
+        // Should not have frame_2 or higher (limited to 2)
+        $this->assertArrayNotHasKey('frame_2', $result['extra']);
+        $this->assertArrayNotHasKey('frame_3', $result['extra']);
+    }
+    
+    public function test_default_constructor_limits_frames()
+    {
+        $processor = new SourceLocationProcessor();
+        
+        $record = [
+            'message' => 'Test log message',
+            'level' => 200,
+            'extra' => []
+        ];
+        
+        $result = $processor($record);
+        
+        // Should have exactly 3 frame fields by default
+        $frameKeys = array_filter(array_keys($result['extra']), fn($key) => str_starts_with($key, 'frame_'));
+        $this->assertLessThanOrEqual(3, count($frameKeys), 'Default should limit to 3 frames');
+        
+        // Should not create excessive frame fields
+        $this->assertArrayNotHasKey('frame_10', $result['extra']);
+        $this->assertArrayNotHasKey('frame_43', $result['extra']);
+    }
+    
+    public function test_adds_source_file_and_line()
+    {
+        $processor = new SourceLocationProcessor();
+        
+        $record = [
+            'message' => 'Test log message',
+            'level' => 200,
+            'extra' => []
+        ];
+        
+        $result = $processor($record);
+        
+        // Should add source location (this test file)
+        $this->assertArrayHasKey('source_file', $result['extra']);
+        $this->assertArrayHasKey('source_line', $result['extra']);
+        $this->assertStringContainsString('SourceLocationProcessorTest.php', $result['extra']['source_file']);
+        $this->assertIsInt($result['extra']['source_line']);
+    }
+    
+    public function test_constructor_validates_parameters()
+    {
+        // Test minimum values are enforced
+        $processor = new SourceLocationProcessor(maxFrames: 0, outputFrames: 0);
+        
+        $record = [
+            'message' => 'Test log message',
+            'level' => 200,
+            'extra' => []
+        ];
+        
+        $result = $processor($record);
+        
+        // Should have at least 1 frame field even with invalid constructor params
+        $frameKeys = array_filter(array_keys($result['extra']), fn($key) => str_starts_with($key, 'frame_'));
+        $this->assertGreaterThanOrEqual(1, count($frameKeys), 'Should enforce minimum of 1 frame');
+    }
+    
+    public function test_output_frames_cannot_exceed_max_frames()
+    {
+        // Try to set outputFrames higher than maxFrames
+        $processor = new SourceLocationProcessor(maxFrames: 2, outputFrames: 5);
+        
+        $record = [
+            'message' => 'Test log message',
+            'level' => 200,
+            'extra' => []
+        ];
+        
+        $result = $processor($record);
+        
+        // Should be capped at maxFrames
+        $frameKeys = array_filter(array_keys($result['extra']), fn($key) => str_starts_with($key, 'frame_'));
+        $this->assertLessThanOrEqual(2, count($frameKeys), 'outputFrames should be capped at maxFrames');
+    }
+}

--- a/tests/Unit/SourceLocationProcessorTest.php
+++ b/tests/Unit/SourceLocationProcessorTest.php
@@ -7,7 +7,7 @@ use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 
 class SourceLocationProcessorTest extends TestCase
 {
-    public function test_limits_frame_fields_to_prevent_es_explosion()
+    public function test_limits_frame_fields_to_prevent_field_explosion()
     {
         // Create processor with custom limits
         $processor = new SourceLocationProcessor(maxFrames: 5, outputFrames: 2);


### PR DESCRIPTION
this caused a lovely ingest error on elasticsearch due to field explosion. ie very deep stack traces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for backtrace depth and the number of frame fields included in log records.
  * Enhanced source location logging with clearer file and line number information.

* **Bug Fixes**
  * Improved compatibility with multiple versions of Monolog for consistent logging behavior.

* **Tests**
  * Introduced comprehensive tests to verify frame limits, source location inclusion, and constructor parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->