### PR TITLE
intercom use external_id NOT user_id

### DIFF
--- a/src/Services/IntercomService.php
+++ b/src/Services/IntercomService.php
@@ -84,11 +84,11 @@ class IntercomService
                 ]),
             ];
 
-            // Use email field if userId looks like an email, otherwise use user_id
+            // Use email field if userId looks like an email, otherwise use external_id
             if (filter_var($userId, FILTER_VALIDATE_EMAIL)) {
                 $eventData['email'] = $userId;
             } else {
-                $eventData['user_id'] = $userId;
+                $eventData['external_id'] = $userId;
             }
 
             $response = $this->makeApiRequest('POST', '/events', $eventData);
@@ -276,11 +276,11 @@ class IntercomService
 
                 $userId = $event['user_id'] ?? '';
 
-                // Use email field if userId looks like an email, otherwise use user_id
+                // Use email field if userId looks like an email, otherwise use external_id
                 if (filter_var($userId, FILTER_VALIDATE_EMAIL)) {
                     $eventData['email'] = $userId;
                 } else {
-                    $eventData['user_id'] = $userId;
+                    $eventData['external_id'] = $userId;
                 }
 
                 $bulkData['events'][] = $eventData;

--- a/tests/Feature/IntercomIntegrationTest.php
+++ b/tests/Feature/IntercomIntegrationTest.php
@@ -81,7 +81,7 @@ class IntercomIntegrationTest extends TestCase
             $data = $request->data();
 
             return $request->url() === 'https://api.intercom.io/events' &&
-                   $data['user_id'] === 'user-123' &&
+                   $data['external_id'] === 'user-123' &&
                    $data['event_name'] === 'connect_product_viewed' &&
                    $data['metadata']['product_id'] === 'prod-456' &&
                    $data['metadata']['tenant_id'] === 'tenant-789' &&

--- a/tests/Unit/Services/IntercomServiceTest.php
+++ b/tests/Unit/Services/IntercomServiceTest.php
@@ -80,7 +80,7 @@ class IntercomServiceTest extends TestCase
 
             return $request->url() === 'https://api.intercom.io/events' &&
                    $request->method() === 'POST' &&
-                   $data['user_id'] === 'user-123' &&
+                   $data['external_id'] === 'user-123' &&
                    $data['event_name'] === 'connect_product_viewed' &&
                    $data['metadata']['service'] === 'connect-service-test' &&
                    $data['metadata']['product_id'] === 'prod-456' &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user identification in event tracking to use "external_id" instead of "user_id" when the user is not identified by email, ensuring accurate event reporting.

* **Tests**
  * Adjusted tests to expect "external_id" in event payloads, reflecting the updated user identification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->