### PR TITLE
Con 1239 fix laravel 10 support

### DIFF
--- a/src/Logging/SentryHandler.php
+++ b/src/Logging/SentryHandler.php
@@ -28,7 +28,7 @@ class SentryHandler extends AbstractProcessingHandler
             // Handle both Monolog 2.x array format and 3.x LogRecord (laravel >=10)
             $context = is_array($record) ? $record['context'] : $record->context;
             $message = is_array($record) ? $record['message'] : $record->message;
-            $level = is_array($record) ? $record['level'] : $record->level;
+            $level = is_array($record) ? $record['level'] : $record->level->value;
 
             // Configure Sentry scope with any tags from context
             configureScope(function (Scope $scope) use ($context): void {
@@ -62,7 +62,6 @@ class SentryHandler extends AbstractProcessingHandler
                 }
 
             } else {
-                // todo For Monolog 3.x, level is an object, for 2.x it's an integer
                 captureMessage($message, $this->getMonologLevelToSeverity($level));
             }
         }

--- a/tests/Unit/Console/ScheduleRunCommandTest.php
+++ b/tests/Unit/Console/ScheduleRunCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Events\Dispatcher;
+use Mockery;
+use NuiMarkets\LaravelSharedUtils\Console\Commands\ScheduleRunCommand;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+class ScheduleRunCommandTest extends TestCase
+{
+    protected Schedule $schedule;
+    protected Dispatcher $dispatcher;
+    protected ExceptionHandler $handler;
+    protected Cache $cache;
+    protected function setUp(): void
+    {
+        $this->schedule = Mockery::mock(Schedule::class);
+        $this->dispatcher = Mockery::mock(Dispatcher::class);
+        $this->handler = Mockery::mock(ExceptionHandler::class);
+        $this->cache = Mockery::mock(Cache::class);
+        $this->schedule->shouldReceive('dueEvents')->once()->andReturn([]);
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_handle_with_laravel_9_signature()
+    {
+        $command = new ScheduleRunCommand;
+        $command->setLaravel($this->app);
+
+        // Act - Call with Laravel 9 signature (3 arguments)
+        $command->handle($this->schedule, $this->dispatcher, $this->handler);
+
+        // Assert - Verify the properties were set correctly
+        $reflection = new \ReflectionClass($command);
+
+        $scheduleProperty = $reflection->getProperty('schedule');
+        $this->assertSame($this->schedule, $scheduleProperty->getValue($command));
+
+        $dispatcherProperty = $reflection->getProperty('dispatcher');
+        $this->assertSame($this->dispatcher, $dispatcherProperty->getValue($command));
+
+        $handlerProperty = $reflection->getProperty('handler');
+        $this->assertSame($this->handler, $handlerProperty->getValue($command));
+    }
+
+    public function test_handle_with_laravel_10_signature()
+    {
+        $command = new ScheduleRunCommand;
+        $command->setLaravel($this->app);
+
+        // Act - Call with Laravel 10 signature (4 arguments)
+        $command->handle($this->schedule, $this->dispatcher, $this->cache, $this->handler);
+
+        // Assert - Verify the properties were set correctly (cache should be ignored)
+        $reflection = new \ReflectionClass($command);
+
+        $scheduleProperty = $reflection->getProperty('schedule');
+        $this->assertSame($this->schedule, $scheduleProperty->getValue($command));
+
+        $dispatcherProperty = $reflection->getProperty('dispatcher');
+        $this->assertSame($this->dispatcher, $dispatcherProperty->getValue($command));
+
+        $handlerProperty = $reflection->getProperty('handler');
+        $this->assertSame($this->handler, $handlerProperty->getValue($command));
+    }
+
+    public function test_handle_processes_no_due_events()
+    {
+        $command = new ScheduleRunCommand;
+        $command->setLaravel($this->app);
+
+        // Act
+        $command->handle($this->schedule, $this->dispatcher, $this->handler);
+
+        // Assert - eventsRan should be false when no events are due
+        $reflection = new \ReflectionClass($command);
+        $eventsRanProperty = $reflection->getProperty('eventsRan');
+        $this->assertFalse($eventsRanProperty->getValue($command));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added compatibility with Laravel 9 and 10+ for the scheduled tasks runner.
  * Enabled logging compatibility with Monolog 2 and 3 for environment processing, Slack, and Sentry handlers.
* Bug Fixes
  * Corrected severity level mapping for Sentry with newer Monolog versions.
  * Prevented internal “slack” flag from appearing in log payloads.
* Tests
  * Added unit tests covering the scheduler command across supported framework versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->