### PR TITLE
fix: remove meta from json response to follow standard

### DIFF
--- a/src/Exceptions/BaseErrorHandler.php
+++ b/src/Exceptions/BaseErrorHandler.php
@@ -248,10 +248,6 @@ class BaseErrorHandler extends ExceptionHandler
         }
 
         return new JsonResponse([
-            'meta' => [
-                'message' => $errorData['title'],
-                'status' => $errorData['status'],
-            ],
             'errors' => $errorData['errors'],
         ], $errorData['status']);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified API error responses by removing the top-level meta block (message, status).
  * Responses now return only the errors array with per-error details.
  * HTTP status is communicated via the response status code, not in the payload.
  * Error item structure remains unchanged.
  * API consumers should update parsing logic to rely on the errors array and HTTP status code; integrations expecting the former meta block will need adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->