### PR TITLE
fix type hint for CustomizeMonoLog

### DIFF
--- a/src/Logging/CustomizeMonoLog.php
+++ b/src/Logging/CustomizeMonoLog.php
@@ -19,8 +19,13 @@ class CustomizeMonoLog
 {
     /**
      * Customize the Monolog instance.
+     *
+     * Laravel's tap configuration passes Illuminate\Log\Logger (wrapper),
+     * which proxies all method calls to the underlying Monolog instance.
+     *
+     * @param  \Illuminate\Log\Logger  $logger
      */
-    public function __invoke(\Monolog\Logger $logger): void
+    public function __invoke($logger): void
     {
         // Add target processor for Elasticsearch routing
         $targetProcessor = $this->createTargetProcessor();


### PR DESCRIPTION
  Changes:
  - Removed strict \Monolog\Logger type hint
  - Added PHPDoc explaining Laravel's wrapper behavior
  - Documented that Illuminate\Log\Logger proxies method calls

Seems to be causing issue in Laravel9

