### PR TITLE
feat(logging): extract Sentry replay ID from request headers

### DIFF
--- a/src/Http/Middleware/RequestLoggingMiddleware.php
+++ b/src/Http/Middleware/RequestLoggingMiddleware.php
@@ -162,6 +162,7 @@ abstract class RequestLoggingMiddleware
             LogFields::REQUEST_PATH => $request->path(),
             LogFields::REQUEST_IP => $request->ip(),
             LogFields::REQUEST_USER_AGENT => $request->userAgent(),
+            LogFields::SENTRY_REPLAY_ID => $request->headers->get('X-Sentry-Replay-Id'),
         ];
     }
 

--- a/src/Logging/LogFields.php
+++ b/src/Logging/LogFields.php
@@ -69,6 +69,8 @@ abstract class LogFields
 
     const TRACE_ID_HEADER = 'request.amz_trace_id';
 
+    const SENTRY_REPLAY_ID = 'request.sentry_replay_id';
+
     // User and organization fields
     const USER_ID = 'user_id'; // PII: Personal identifier
 


### PR DESCRIPTION
## Summary
- Add `SENTRY_REPLAY_ID` constant to `LogFields`
- Extract `X-Sentry-Replay-Id` header in `RequestLoggingMiddleware::buildBaseContext()`


## Backwards compatibility
Additive only. The new field is `null` when the header isn't present, matching the existing `amz_trace_id` pattern. No consuming service changes needed.

## Changes
```
 src/Http/Middleware/RequestLoggingMiddleware.php | 1 +
 src/Logging/LogFields.php                       | 2 ++
 2 files changed, 3 insertions(+)
```

## Test plan
- [x] All 469 tests pass
- [x] Lint clean (no new issues)
- [ ] Verify `request.sentry_replay_id` appears in ES logs when header is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request logging now captures Sentry Replay ID from incoming HTTP headers, extending the logging context with replay identifiers for improved session tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->