### PR TITLE
fix(logging): emit response.status as flat top-level field

### DIFF
--- a/src/Http/Middleware/RequestLoggingMiddleware.php
+++ b/src/Http/Middleware/RequestLoggingMiddleware.php
@@ -291,13 +291,13 @@ abstract class RequestLoggingMiddleware
             LogFields::TARGET => $this->getServiceName(),
             LogFields::FEATURE => 'requests',
             LogFields::ACTION => 'request.complete',
+            LogFields::RESPONSE_STATUS => $statusCode,
             'request' => [
                 'method' => $request->method(),
                 'path' => $request->path(),
                 'route_name' => $request->route() ? $request->route()->getName() : 'unknown',
             ],
             'response' => [
-                LogFields::STATUS => $statusCode,
                 LogFields::RESPONSE_SIZE_BYTES => $responseSize,
             ],
             'performance' => $metrics,

--- a/src/Logging/LogFields.php
+++ b/src/Logging/LogFields.php
@@ -95,6 +95,8 @@ abstract class LogFields
 
     const STATUS = 'status';
 
+    const RESPONSE_STATUS = 'response.status';
+
     const RESULT = 'result';
 
     // Error and exception fields
@@ -249,6 +251,7 @@ abstract class LogFields
                 'REQUEST_ID' => self::REQUEST_ID,
                 'REQUEST_METHOD' => self::REQUEST_METHOD,
                 'REQUEST_PATH' => self::REQUEST_PATH,
+                'RESPONSE_STATUS' => self::RESPONSE_STATUS,
                 // Basic request properties
                 'REQUEST_IP' => self::REQUEST_IP,
                 'REQUEST_USER_AGENT' => self::REQUEST_USER_AGENT,

--- a/tests/Unit/Http/Middleware/RequestLoggingMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/RequestLoggingMiddlewareTest.php
@@ -415,6 +415,28 @@ class RequestLoggingMiddlewareTest extends TestCase
         Log::shouldHaveReceived('info')->with('Request start', \Mockery::type('array'));
         Log::shouldHaveReceived('info')->with('Request complete', \Mockery::type('array'));
     }
+
+    public function test_response_status_logged_as_flat_top_level_field()
+    {
+        $request = Request::create('/api/orders', 'GET');
+        $response = new Response('Not Found', 404);
+
+        $this->middleware->handle($request, function ($req) use ($response) {
+            return $response;
+        });
+
+        // response.status must be a top-level flat key (dot-notation) so the
+        // ingestion Lambda can promote it into an indexed ES field. A nested
+        // ['response' => ['status' => 404]] structure gets buried in `data.*`
+        // and cannot be searched with `response.status:4xx` range queries.
+        Log::shouldHaveReceived('info')->with(
+            'Request complete',
+            \Mockery::on(function ($context) {
+                return ($context['response.status'] ?? null) === 404
+                    && ! isset($context['response']['status']);
+            })
+        );
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

- `RequestLoggingMiddleware` emitted HTTP response status as a nested key (`['response' => ['status' => 200]]`) in the "Request complete" log.
- Log ingestion pipelines that promote dot-notation keys to indexed fields expect `response.status` as a literal top-level key (matching how `request.method`, `request.path`, etc. are already emitted). The nested form never matches the flat-key promotion logic, leaving the status unindexed in `data.*`.
- Flatten `response.status` to the top level via a new `LogFields::RESPONSE_STATUS` constant. `response_size_bytes` stays nested since it isn't typically promoted.

## Backwards compatibility

- Consumers parsing the `Request complete` log structure that relied on `response.status` being nested under `response` will need to read the top-level `response.status` key instead. The nested `response` entry still exists (now only carries `response_size_bytes`).
- No change to other log entries or to `LogFields::STATUS` (which remains a generic status constant for other use cases).

## Test plan

- [x] New unit test `test_response_status_logged_as_flat_top_level_field` asserts the flat key is present and the nested form is absent
- [x] Full test suite green (488 passed, 10 skipped on unrelated Redis-dependent feature tests)
- [x] Pint clean on modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request logs now include the response status as a top-level field (response.status), ensuring status codes are easily accessible in log summaries rather than nested.

* **Tests**
  * Added unit test to verify the response status is logged as a flat top-level field and not only nested within the response object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->