### PR TITLE
feat(services): add shared MachineTokenService + provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ php artisan vendor:publish --tag=intercom-config
 | **Intercom Integration** | User analytics and event tracking | [Guide](docs/intercom-integration.md) |
 | **IncludesParser** | API response optimization utility | [Guide](docs/includes-parser.md) |
 | **IAM RDS Connector** | Short-lived IAM tokens for RDS / RDS Proxy | [Guide](docs/iam-rds-connector.md) |
+| **Machine Token** | Client-credentials token retrieval and caching for service-to-service auth | [Guide](docs/machine-token.md) |
 
 ### Quick Examples
 

--- a/config/machine_token.php
+++ b/config/machine_token.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Machine Token Cache Key
+    |--------------------------------------------------------------------------
+    |
+    | The logical cache key used to store the current machine token. Consumer
+    | applications may add a cache prefix, but this suffix should remain stable.
+    |
+    */
+    'redis_key' => env('MACHINE_TOKEN_REDIS_KEY', 'machine_token'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Refresh Window
+    |--------------------------------------------------------------------------
+    |
+    | Number of seconds before token expiry when the service should refresh the
+    | token. The default is seven days.
+    |
+    */
+    'time_before_expire' => (int) env('MACHINE_TOKEN_TIME_BEFORE_EXPIRE', 7 * 24 * 3600),
+
+    'client_id' => env('MACHINE_TOKEN_CLIENT_ID'),
+    'secret' => env('MACHINE_TOKEN_SECRET'),
+    'url' => env('MACHINE_TOKEN_URL'),
+];

--- a/docs/RemoteRepository.md
+++ b/docs/RemoteRepository.md
@@ -10,6 +10,7 @@ The `RemoteRepository` is an abstract base class that provides standardized func
 - [Installation](#installation)
 - [Basic Usage](#basic-usage)
 - [Configuration](#configuration)
+- [Machine Token](#machine-token)
 - [Header Forwarding](#header-forwarding)
 - [Error Handling](#error-handling)
 - [HTTP Status Code Preservation](#http-status-code-preservation)
@@ -193,6 +194,21 @@ PXC_MAX_URL_LENGTH=2048
 PXC_API_LOG_REQUESTS=false
 PXC_USER_RETRIEVE_LIMIT=100
 ```
+
+## Machine Token
+
+`RemoteRepository` depends on `MachineTokenServiceInterface` and loads tokens lazily on the first outbound API request. Applications can bind their own implementation or opt into the shared implementation:
+
+```php
+// config/app.php
+'providers' => [
+    NuiMarkets\LaravelSharedUtils\Providers\MachineTokenServiceProvider::class,
+],
+```
+
+The shared provider binds `MachineTokenServiceInterface` to `MachineTokenService` and reads `machine_token.*` configuration from `config/machine_token.php`.
+
+See [Machine Token](machine-token.md) for installation, environment variables, logging behavior, and test mocking guidance.
 
 ## Header Forwarding
 

--- a/docs/machine-token.md
+++ b/docs/machine-token.md
@@ -1,0 +1,91 @@
+# Machine Token
+
+## Overview
+
+`MachineTokenService` is the shared implementation of `MachineTokenServiceInterface` for client-credentials service-to-service authentication. It retrieves a token from a configured auth endpoint, stores the token payload in Laravel cache, refreshes before expiry, and falls back to the current valid token if refresh temporarily fails.
+
+## Installation
+
+Register the provider in the consuming Laravel app:
+
+```php
+// config/app.php
+'providers' => [
+    NuiMarkets\LaravelSharedUtils\Providers\MachineTokenServiceProvider::class,
+],
+```
+
+Publish the config when the app needs a local config file:
+
+```bash
+php artisan vendor:publish --tag=machine-token-config
+```
+
+The provider binds `NuiMarkets\LaravelSharedUtils\Contracts\MachineTokenServiceInterface` to `NuiMarkets\LaravelSharedUtils\Services\MachineTokenService` as a singleton.
+
+## Configuration
+
+Configuration is read from `config/machine_token.php` under the `machine_token.*` namespace.
+
+| Key | Environment variable | Default | Notes |
+| --- | --- | --- | --- |
+| `machine_token.redis_key` | `MACHINE_TOKEN_REDIS_KEY` | `machine_token` | Logical cache key. Keep the suffix stable for existing revocation tooling. |
+| `machine_token.time_before_expire` | `MACHINE_TOKEN_TIME_BEFORE_EXPIRE` | `604800` | Refresh window in seconds before token expiry. |
+| `machine_token.client_id` | `MACHINE_TOKEN_CLIENT_ID` | `null` | OAuth client ID. |
+| `machine_token.secret` | `MACHINE_TOKEN_SECRET` | `null` | OAuth client secret. |
+| `machine_token.url` | `MACHINE_TOKEN_URL` | `null` | Token endpoint URL. |
+
+## Behavior
+
+```text
+getToken()
+  -> return in-memory token if already loaded this request
+  -> read cached payload from machine_token.redis_key
+  -> return cached token when payload is valid and outside the refresh window
+  -> refresh from auth endpoint when missing, malformed, or near expiry
+  -> cache new token payload and return token
+```
+
+If refresh fails while an old token is still valid, the service returns the old token and logs an error so operators can fix the auth endpoint before the token expires. If no valid old token exists, it throws `RuntimeException`.
+
+## Logging
+
+| Action | Level | Condition |
+| --- | --- | --- |
+| `config_missing` | `warning` | `url`, `client_id`, or `secret` is missing. |
+| `connection_failed` | `warning` | The HTTP request to the token endpoint throws. |
+| `token_refresh_failed` | `error` | Refresh fails while an old token is still valid. |
+
+Warnings use `ErrorLogger::logWarning()` and should not page Slack in normal consumer routing. The refresh failure path uses `ErrorLogger::logError()` because it needs operator attention before the old token expires.
+
+## Testing
+
+Use `MocksMachineTokenService` when a test only needs a token to exist:
+
+```php
+use NuiMarkets\LaravelSharedUtils\Testing\MocksMachineTokenService;
+
+class ProductRepositoryTest extends TestCase
+{
+    use MocksMachineTokenService;
+
+    public function test_repository_call()
+    {
+        $this->mockMachineTokenService('test-token');
+
+        // Exercise code that resolves MachineTokenServiceInterface.
+    }
+}
+```
+
+The trait binds a Mockery double for `MachineTokenServiceInterface`, so tests do not make real HTTP calls to the token endpoint.
+
+## Migration Notes
+
+For existing consumers with a local `App\Services\MachineTokenService`:
+
+1. Require a shared-utils version that includes this component.
+2. Register `MachineTokenServiceProvider` in `config/app.php`.
+3. Delete the local service and provider.
+4. Move `pxc.machine_token.*` values to `machine_token.*`.
+5. Remove the old `pxc.machine_token` config block once all references are gone.

--- a/src/Logging/ErrorLogger.php
+++ b/src/Logging/ErrorLogger.php
@@ -139,7 +139,8 @@ class ErrorLogger
      * @param  string  $errorType  The type of error (e.g., 'database', 'file_system', 'permission')
      * @param  string  $message  The error message
      * @param  array  $context  Additional context to include
-     * @param  string  $level  The log level to use (default: 'error')
+     * @param  string  $level  The log level to use (default: 'error'). Prefer a dedicated
+     *                         method such as logWarning() for non-error severities.
      */
     public static function logError(string $errorType, string $message, array $context = [], string $level = 'error'): void
     {
@@ -151,6 +152,18 @@ class ErrorLogger
         $fullContext = array_merge($errorContext, $context);
 
         static::logWithLevel($level, $message, $fullContext);
+    }
+
+    /**
+     * Log a custom warning with consistent formatting.
+     *
+     * @param  string  $errorType  The type of warning
+     * @param  string  $message  The warning message
+     * @param  array  $context  Additional context to include
+     */
+    public static function logWarning(string $errorType, string $message, array $context = []): void
+    {
+        static::logError($errorType, $message, $context, 'warning');
     }
 
     /**

--- a/src/Providers/MachineTokenServiceProvider.php
+++ b/src/Providers/MachineTokenServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use NuiMarkets\LaravelSharedUtils\Contracts\MachineTokenServiceInterface;
+use NuiMarkets\LaravelSharedUtils\Services\MachineTokenService;
+
+class MachineTokenServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../config/machine_token.php', 'machine_token');
+
+        $this->app->singleton(MachineTokenService::class);
+        $this->app->singleton(MachineTokenServiceInterface::class, function ($app): MachineTokenService {
+            return $app->make(MachineTokenService::class);
+        });
+    }
+
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../../config/machine_token.php' => config_path('machine_token.php'),
+            ], 'machine-token-config');
+        }
+    }
+}

--- a/src/Services/MachineTokenService.php
+++ b/src/Services/MachineTokenService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Services;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use NuiMarkets\LaravelSharedUtils\Contracts\MachineTokenServiceInterface;
+use NuiMarkets\LaravelSharedUtils\Logging\ErrorLogger;
+use NuiMarkets\LaravelSharedUtils\Logging\LogFields;
+
+use function config;
+
+class MachineTokenService implements MachineTokenServiceInterface
+{
+    /** Cache token for any subsequent calls to get within this request. */
+    private string $tokenString = '';
+
+    private ?array $oldToken = null;
+
+    public function getToken(): string
+    {
+        if ($this->tokenString === '') {
+            /** Try redis */
+            $token = Cache::get(config('machine_token.redis_key'));
+
+            /** Check expiry, throw it away if too old */
+            if ($token) {
+                if (! is_array($token) or empty($token['expiry']) or empty($token['token'])) {
+                    /** Something wrong with it, get a new one. */
+                    $token = null;
+                } else {
+                    $expiry = strtotime($token['expiry']);
+                    $timeForNew = $expiry - config('machine_token.time_before_expire');
+                    if (time() > $timeForNew) {
+                        /** time for a new token */
+                        $this->oldToken = $token;
+                        $token = null;
+                    }
+                }
+            }
+
+            if (! $token) {
+                /** Retrieve new token and store in redis */
+                $token = $this->retrieveFromAuth();
+                Cache::put(config('machine_token.redis_key'), $token);
+            }
+
+            /** Cache in RAM for any other calls THIS request. */
+            $this->tokenString = $token['token'];
+        }
+
+        return $this->tokenString;
+    }
+
+    private function retrieveFromAuth(): array
+    {
+        $url = config('machine_token.url');
+        $clientId = config('machine_token.client_id');
+        $clientSecret = config('machine_token.secret');
+
+        // Guard against missing configuration.
+        if (! $url || ! $clientId || ! $clientSecret) {
+            ErrorLogger::logWarning('machine_token_config_missing', 'Machine token configuration incomplete', [
+                LogFields::FEATURE => 'machine_token',
+                LogFields::ACTION => 'config_missing',
+                'has_url' => ! empty($url),
+                'has_client_id' => ! empty($clientId),
+                'has_secret' => ! empty($clientSecret),
+            ]);
+
+            return $this->panic();
+        }
+
+        try {
+            $response = Http::accept('application/json')
+                ->post($url, [
+                    'grant_type' => 'client_credentials',
+                    'client_id' => $clientId,
+                    'client_secret' => $clientSecret,
+                    'scopes' => '',
+                ]);
+
+            if ($response->failed()) {
+                return $this->panic();
+            }
+        } catch (\Exception $e) {
+            ErrorLogger::logWarning('machine_token_connection_failed', 'Failed to retrieve token from machine token service: '.$e->getMessage(), [
+                LogFields::FEATURE => 'machine_token',
+                LogFields::ACTION => 'connection_failed',
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->panic();
+        }
+
+        $body = $response->body();
+        $data = json_decode($body, true);
+
+        if (! is_array($data) || empty($data['access_token']) || empty($data['expires_in'])) {
+            return $this->panic();
+        }
+
+        $expiry = Carbon::createFromTimestamp(time() + $data['expires_in']);
+
+        $token = [
+            'token' => $data['access_token'],
+            'expiry' => $expiry->toIso8601String(),
+        ];
+
+        return $token;
+    }
+
+    private function panic(): array
+    {
+        if ($this->oldToken) {
+            /** Mild Panic */
+            $expiry = strtotime($this->oldToken['expiry']);
+            if (time() < $expiry) {
+                /** Send message to slack to fix things before token really expires */
+                ErrorLogger::logError('machine_token_refresh_failed', 'Could not get a new machine token. Current one expires: '.$this->oldToken['expiry'], [
+                    LogFields::FEATURE => 'machine_token',
+                    LogFields::ACTION => 'token_refresh_failed',
+                    'token_expiry' => $this->oldToken['expiry'],
+                ]);
+
+                return $this->oldToken;
+            }
+        }
+        /** Full Panic. We don't have an old token, or the old one has expired */
+        throw new \RuntimeException('Could not get new machine token.');
+    }
+}

--- a/src/Testing/MocksMachineTokenService.php
+++ b/src/Testing/MocksMachineTokenService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Testing;
+
+use Mockery;
+use Mockery\MockInterface;
+use NuiMarkets\LaravelSharedUtils\Contracts\MachineTokenServiceInterface;
+use NuiMarkets\LaravelSharedUtils\Services\MachineTokenService;
+
+trait MocksMachineTokenService
+{
+    protected function mockMachineTokenService(string $token = 'fake-token'): MockInterface
+    {
+        $mockMachineTokenService = Mockery::mock(MachineTokenService::class);
+        $mockMachineTokenService->shouldReceive('getToken')->andReturn($token)->byDefault();
+
+        // Bind to both the interface and the concrete so consumers that resolve
+        // either get the mock. The shared provider exposes both bindings.
+        app()->instance(MachineTokenServiceInterface::class, $mockMachineTokenService);
+        app()->instance(MachineTokenService::class, $mockMachineTokenService);
+
+        return $mockMachineTokenService;
+    }
+}

--- a/tests/Feature/MachineTokenServiceProviderTest.php
+++ b/tests/Feature/MachineTokenServiceProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Feature;
+
+use NuiMarkets\LaravelSharedUtils\Contracts\MachineTokenServiceInterface;
+use NuiMarkets\LaravelSharedUtils\Providers\MachineTokenServiceProvider;
+use NuiMarkets\LaravelSharedUtils\Services\MachineTokenService;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+class MachineTokenServiceProviderTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            MachineTokenServiceProvider::class,
+        ];
+    }
+
+    public function test_provider_merges_default_config()
+    {
+        $this->assertEquals('machine_token', config('machine_token.redis_key'));
+        $this->assertEquals(7 * 24 * 3600, config('machine_token.time_before_expire'));
+    }
+
+    public function test_provider_binds_interface_to_singleton_service()
+    {
+        $first = app(MachineTokenServiceInterface::class);
+        $second = app(MachineTokenServiceInterface::class);
+
+        $this->assertInstanceOf(MachineTokenService::class, $first);
+        $this->assertSame($first, $second);
+        $this->assertSame(app(MachineTokenService::class), $first);
+    }
+}

--- a/tests/Unit/Logging/ErrorLoggerTest.php
+++ b/tests/Unit/Logging/ErrorLoggerTest.php
@@ -282,4 +282,21 @@ class ErrorLoggerTest extends TestCase
             })
         );
     }
+
+    public function test_log_warning_uses_warning_level()
+    {
+        ErrorLogger::logWarning('configuration', 'Configuration is incomplete', [
+            'feature' => 'machine_token',
+        ]);
+
+        Log::shouldHaveReceived('warning')->once()->with(
+            'Configuration is incomplete',
+            \Mockery::on(function ($context) {
+                return $context['error_type'] === 'configuration' &&
+                       $context['error_message'] === 'Configuration is incomplete' &&
+                       $context['feature'] === 'machine_token';
+            })
+        );
+        Log::shouldNotHaveReceived('error');
+    }
 }

--- a/tests/Unit/Services/MachineTokenServiceRedisKeyTest.php
+++ b/tests/Unit/Services/MachineTokenServiceRedisKeyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use NuiMarkets\LaravelSharedUtils\Services\MachineTokenService;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+class MachineTokenServiceRedisKeyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+        Cache::flush();
+
+        Config::set('machine_token.redis_key', 'machine_token');
+        Config::set('machine_token.time_before_expire', 300);
+        Config::set('machine_token.url', 'https://auth.test.com/token');
+        Config::set('machine_token.client_id', 'test_client_id');
+        Config::set('machine_token.secret', 'test_client_secret');
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::flush();
+
+        parent::tearDown();
+    }
+
+    public function test_successful_token_request_uses_literal_machine_token_cache_key()
+    {
+        Http::fake([
+            'https://auth.test.com/token' => Http::response([
+                'access_token' => 'new_jwt_token_12345',
+                'expires_in' => 3600,
+            ], 200),
+        ]);
+
+        $token = (new MachineTokenService)->getToken();
+
+        $this->assertEquals('new_jwt_token_12345', $token);
+        $this->assertTrue(Cache::has('machine_token'));
+        $this->assertEquals('new_jwt_token_12345', Cache::get('machine_token')['token']);
+    }
+}

--- a/tests/Unit/Services/MachineTokenServiceTest.php
+++ b/tests/Unit/Services/MachineTokenServiceTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Services;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use NuiMarkets\LaravelSharedUtils\Services\MachineTokenService;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use RuntimeException;
+
+class MachineTokenServiceTest extends TestCase
+{
+    private MachineTokenService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cache.default', 'array');
+        Cache::flush();
+
+        Config::set('machine_token.redis_key', 'test_machine_token');
+        Config::set('machine_token.time_before_expire', 300);
+        Config::set('machine_token.url', 'https://auth.test.com/token');
+        Config::set('machine_token.client_id', 'test_client_id');
+        Config::set('machine_token.secret', 'test_client_secret');
+
+        $this->service = new MachineTokenService;
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::flush();
+
+        parent::tearDown();
+    }
+
+    public function test_get_token_returns_cached_token_without_http_request()
+    {
+        $cachedToken = 'cached_jwt_token_67890';
+        $expiry = Carbon::now()->addHours(2)->toIso8601String();
+
+        Cache::put('test_machine_token', [
+            'token' => $cachedToken,
+            'expiry' => $expiry,
+        ]);
+
+        Http::fake();
+
+        $token = $this->service->getToken();
+
+        $this->assertEquals($cachedToken, $token);
+        Http::assertNothingSent();
+    }
+
+    public function test_token_inside_refresh_window_retrieves_new_token()
+    {
+        $oldToken = 'old_jwt_token_11111';
+        $newToken = 'new_jwt_token_22222';
+        $nearExpiryTime = Carbon::now()->addSeconds(200)->toIso8601String();
+
+        Cache::put('test_machine_token', [
+            'token' => $oldToken,
+            'expiry' => $nearExpiryTime,
+        ]);
+
+        Http::fake([
+            'https://auth.test.com/token' => Http::response([
+                'access_token' => $newToken,
+                'expires_in' => 3600,
+            ], 200),
+        ]);
+
+        $token = $this->service->getToken();
+
+        $this->assertEquals($newToken, $token);
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://auth.test.com/token' &&
+                   $request['grant_type'] === 'client_credentials' &&
+                   $request['client_id'] === 'test_client_id' &&
+                   $request['client_secret'] === 'test_client_secret';
+        });
+    }
+
+    public function test_mild_panic_returns_old_token_and_logs_error()
+    {
+        $oldToken = 'old_but_valid_token_66666';
+        $expiry = Carbon::now()->addSeconds(200)->toIso8601String();
+
+        Cache::put('test_machine_token', [
+            'token' => $oldToken,
+            'expiry' => $expiry,
+        ]);
+
+        Http::fake([
+            'https://auth.test.com/token' => Http::response(['error' => 'service_unavailable'], 500),
+        ]);
+
+        Log::shouldReceive('error')->once()->with(
+            'Could not get a new machine token. Current one expires: '.$expiry,
+            Mockery::on(function ($context) use ($expiry) {
+                return $context['error_type'] === 'machine_token_refresh_failed' &&
+                       $context['feature'] === 'machine_token' &&
+                       $context['action'] === 'token_refresh_failed' &&
+                       $context['token_expiry'] === $expiry;
+            })
+        );
+        Log::shouldReceive('warning')->never();
+
+        $token = $this->service->getToken();
+
+        $this->assertEquals($oldToken, $token);
+    }
+
+    public function test_full_panic_throws_when_refresh_fails_without_old_token()
+    {
+        Http::fake([
+            'https://auth.test.com/token' => Http::response(['error' => 'service_unavailable'], 500),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not get new machine token.');
+
+        $this->service->getToken();
+    }
+
+    public function test_missing_configuration_logs_warning_and_throws_without_http_request()
+    {
+        Config::set('machine_token.url', null);
+
+        Http::fake();
+
+        Log::shouldReceive('warning')->once()->with(
+            'Machine token configuration incomplete',
+            Mockery::on(function ($context) {
+                return $context['error_type'] === 'machine_token_config_missing' &&
+                       $context['feature'] === 'machine_token' &&
+                       $context['action'] === 'config_missing' &&
+                       $context['has_url'] === false &&
+                       $context['has_client_id'] === true &&
+                       $context['has_secret'] === true;
+            })
+        );
+        Log::shouldReceive('error')->never();
+
+        try {
+            $this->service->getToken();
+            $this->fail('Expected missing configuration to throw.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Could not get new machine token.', $e->getMessage());
+        } finally {
+            Http::assertNothingSent();
+        }
+    }
+
+    public function test_malformed_token_response_missing_access_token_triggers_panic()
+    {
+        Http::fake([
+            'https://auth.test.com/token' => Http::response([
+                'expires_in' => 3600,
+            ], 200),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not get new machine token.');
+
+        $this->service->getToken();
+    }
+
+    public function test_malformed_token_response_missing_expires_in_triggers_panic()
+    {
+        Http::fake([
+            'https://auth.test.com/token' => Http::response([
+                'access_token' => 'new_jwt_token_99999',
+            ], 200),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not get new machine token.');
+
+        $this->service->getToken();
+    }
+
+    public function test_connection_failure_logs_warning_and_throws_without_old_token()
+    {
+        Http::fake(function () {
+            throw new \Exception('connection refused');
+        });
+
+        Log::shouldReceive('warning')->once()->with(
+            'Failed to retrieve token from machine token service: connection refused',
+            Mockery::on(function ($context) {
+                return $context['error_type'] === 'machine_token_connection_failed' &&
+                       $context['feature'] === 'machine_token' &&
+                       $context['action'] === 'connection_failed' &&
+                       $context['error'] === 'connection refused';
+            })
+        );
+        Log::shouldReceive('error')->never();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not get new machine token.');
+
+        $this->service->getToken();
+    }
+}

--- a/tests/Unit/Testing/MocksMachineTokenServiceTest.php
+++ b/tests/Unit/Testing/MocksMachineTokenServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Testing;
+
+use Illuminate\Support\Facades\Http;
+use NuiMarkets\LaravelSharedUtils\Contracts\MachineTokenServiceInterface;
+use NuiMarkets\LaravelSharedUtils\Services\MachineTokenService;
+use NuiMarkets\LaravelSharedUtils\Testing\MocksMachineTokenService;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+class MocksMachineTokenServiceTest extends TestCase
+{
+    use MocksMachineTokenService;
+
+    public function test_trait_binds_default_token()
+    {
+        $this->mockMachineTokenService();
+
+        $this->assertEquals('fake-token', app(MachineTokenServiceInterface::class)->getToken());
+    }
+
+    public function test_trait_also_binds_concrete_class()
+    {
+        $this->mockMachineTokenService('concrete-token');
+
+        $this->assertEquals('concrete-token', app(MachineTokenService::class)->getToken());
+    }
+
+    public function test_trait_binds_custom_token()
+    {
+        $this->mockMachineTokenService('custom-token');
+
+        $this->assertEquals('custom-token', app(MachineTokenServiceInterface::class)->getToken());
+    }
+
+    public function test_trait_does_not_make_real_http_request()
+    {
+        Http::fake();
+
+        $this->mockMachineTokenService();
+
+        app(MachineTokenServiceInterface::class)->getToken();
+
+        Http::assertNothingSent();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MachineTokenService` implementing `MachineTokenServiceInterface` with Redis-cached client-credentials tokens, refresh-window scheduling, and mild-panic fallback to the previous token while logging an error.
- Add `MachineTokenServiceProvider` for opt-in registration; binds the interface to the concrete as a singleton, mirrors `IamRdsServiceProvider` conventions (`mergeConfigFrom` in `register`, publishes-tag in `boot`).
- Add `MocksMachineTokenService` test trait so consumer tests can stub a token with one line instead of cloning Mockery boilerplate per test class. Binds both interface and concrete so callers resolving either get the mock.
- Add `ErrorLogger::logWarning()` helper to make the warning-vs-error log level explicit at the call site (the `level` arg on `logError()` is regression-prone, a future cleanup could silently flip warnings to errors and start paging Slack).
- Reads config from `machine_token.*` (env vars `MACHINE_TOKEN_*`) and keeps the literal `machine_token` Redis cache-key suffix unchanged so existing revocation tooling continues to work (e.g. `connect-auth/tokens:revoke-client`).
- Ships `docs/machine-token.md` (install, env vars, logging behavior table, test mocking, migration notes for consumers with a local copy).

## Review

- Internal: 5 self-review fixes auto-applied (malformed-response guard bug, missing tests, generic CHANGELOG language, panic return type, `Carbon::createFromTimestamp`, strict comparison, collapsed duplicate CHANGELOG sections).
- External (Codex agentic, Gemini agentic): 1 applied (mock trait now binds concrete class as well as interface). 5 noted as inherited from the connect-order reference (see Known parity issues below).

## Known parity issues (intentional)

This service is a faithful port of an internal  `app/Services/MachineTokenService.php` minus the testing-environment short-circuit, so existing operational characteristics are preserved. Reviewers flagged the following; all are inherited and out of scope for this consolidation PR. They can be addressed as separate enhancements once all four consumers are on the shared implementation:

- **In-memory `\$tokenString` + singleton binding**: in long-lived Laravel processes (queue workers, Horizon, Octane), the first token resolved on the singleton is held forever until the process restarts. The Redis cache layer's refresh-window check is bypassed for the lifetime of the in-memory string. Matches connect-order's `singleton(MachineTokenService::class)` + `bind(MachineTokenServiceInterface::class, MachineTokenService::class)` resolution chain.
- **Mild-panic returns old token without caller-visible signal**: refresh-failure with a still-valid old token logs an error (Slack-pageable) and returns the old token as a normal success. Callers cannot distinguish "fresh" from "fallback".
- **7-day default `time_before_expire`**: tokens with TTL shorter than 7 days will refresh on every request. Production NUI machine tokens have TTL > 7 days so this is benign today, but the default is aggressive for general use. Configurable via `MACHINE_TOKEN_TIME_BEFORE_EXPIRE` env var.
- **No `Cache::lock()` thundering-herd guard**: concurrent requests on cache miss all enter `retrieveFromAuth()` together.
- **Mixed `strtotime`/`Carbon` style**: cosmetic only.

## Changes

\`\`\`
 CHANGELOG.md                                       | 209 +++++++++++++++++
 CLAUDE.md                                          | 260 +++++++++++++++++++++
 README.md                                          |   1 +
 config/machine_token.php                           |  29 +++
 docs/RemoteRepository.md                           |  16 ++
 docs/machine-token.md                              |  91 ++++++++
 src/Logging/ErrorLogger.php                        |  15 +-
 src/Providers/MachineTokenServiceProvider.php      |  29 +++
 src/Services/MachineTokenService.php               | 133 +++++++++++
 src/Testing/MocksMachineTokenService.php           |  24 ++
 tests/Feature/MachineTokenServiceProviderTest.php  |  34 +++
 tests/Unit/Logging/ErrorLoggerTest.php             |  17 ++
 tests/Unit/Services/MachineTokenServiceRedisKeyTest.php  |  49 ++++
 tests/Unit/Services/MachineTokenServiceTest.php    | 210 +++++++++++++++++
 tests/Unit/Testing/MocksMachineTokenServiceTest.php   |  46 ++++
 15 files changed, 1162 insertions(+), 1 deletion(-)
\`\`\`

## Backwards compatibility

Interface (`MachineTokenServiceInterface`) is unchanged. Provider registration is opt-in (consumers add it to `config/app.php`). Consumers with a local `App\Services\MachineTokenService` continue to work without changes; they migrate atomically per repo when ready.

## Test plan

- [x] 13 new tests cover cache hit, refresh window, mild/full panic, config guard, connection failure, malformed responses (missing `access_token`, missing `expires_in`), log-level contract (regression sentinel for the warning-vs-error Slack-paging boundary), Redis key suffix preservation, provider binding/singleton identity, mock trait (interface + concrete binding, no real HTTP).
- [x] Full PHPUnit suite green: 523 tests, 1719 assertions.
- [x] Pint clean on touched files.
- [ ] CI matrix (PHP 8.2/8.3 × Laravel 9/10) green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Machine token service for service-to-service auth with Redis-backed caching, automatic refresh and graceful fallback.
  * New warning-level logging helper for structured non-error logs.

* **Documentation**
  * Detailed setup, config reference, env vars, logging behavior, migration steps and test-mocking guidance.

* **Tests**
  * Broad test coverage for provider wiring, token retrieval/caching/refresh, failure modes, and test helpers for mocking the token service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->