### PR TITLE
feat(logging): expose JWT integration features on request logs

### DIFF
--- a/docs/logging-integration.md
+++ b/docs/logging-integration.md
@@ -132,6 +132,29 @@ protected $middlewareGroups = [
 ];
 ```
 
+#### Automatic `integration_features` extraction
+
+When the request is authenticated, the base middleware also emits an
+`integration_features` field listing the user/tenant features whose names start
+with `integration-` (e.g. `integration-create-as-pending`). The field is
+omitted when there are no integration features, so non-integration traffic
+stays uncluttered, and cardinality stays bounded because non-`integration-*`
+features (which can be numerous) are filtered out.
+
+The middleware sources the feature list via a duck-typed contract on the
+authenticated user object:
+
+1. If the user exposes a public `getFeatures(): array` method, it is called.
+2. Otherwise, if the user has a public `$features` property holding an array,
+   it is read.
+3. Otherwise the field is omitted.
+
+The property fallback uses `get_object_vars()` so it does not trigger Eloquent
+magic accessors (e.g. lazy-loading a `features` relation). The method check
+skips non-public methods. No middleware override is needed in consuming
+services; ensure the user resolved by `$request->user()` exposes one of the
+two shapes.
+
 ### 5. Use the Logging Traits in Controllers
 
 ```php

--- a/src/Http/Middleware/RequestLoggingMiddleware.php
+++ b/src/Http/Middleware/RequestLoggingMiddleware.php
@@ -193,6 +193,32 @@ abstract class RequestLoggingMiddleware
                 if ($orgType = $this->getUserOrgType($user)) {
                     $context[LogFields::REQUEST_ORG_TYPE] = $orgType;
                 }
+
+                // Source features without triggering Eloquent magic. ReflectionMethod inspects the actual declared
+                // method so it correctly rejects a non-public getFeatures even when __call is defined (where
+                // is_callable would falsely return true and route the call through __call). get_object_vars() reads
+                // only declared public properties (avoids __isset lazy-loading a `features` relation).
+                $features = null;
+                if (method_exists($user, 'getFeatures')
+                    && (new \ReflectionMethod($user, 'getFeatures'))->isPublic()) {
+                    $features = $user->getFeatures();
+                } else {
+                    $publicProps = get_object_vars($user);
+                    if (isset($publicProps['features']) && is_array($publicProps['features'])) {
+                        $features = $publicProps['features'];
+                    }
+                }
+
+                if (is_array($features)) {
+                    $integrationFeatures = array_values(array_filter(
+                        $features,
+                        static fn ($feature): bool => is_string($feature) && str_starts_with($feature, 'integration-')
+                    ));
+
+                    if ($integrationFeatures !== []) {
+                        $context[LogFields::INTEGRATION_FEATURES] = $integrationFeatures;
+                    }
+                }
             }
         } catch (\Exception $e) {
             // Auth guard not configured or other auth issues - continue without user context

--- a/src/Logging/LogFields.php
+++ b/src/Logging/LogFields.php
@@ -84,6 +84,9 @@ abstract class LogFields
 
     const USER_NAME = 'user_name'; // PII: Personal name
 
+    // Tenant/org capability context (subset of features; integration-* only on request side to bound cardinality)
+    const INTEGRATION_FEATURES = 'integration_features';
+
     // Action and operation fields
     const FEATURE = 'feature';
 
@@ -273,6 +276,7 @@ abstract class LogFields
                 'USER_TYPE' => self::USER_TYPE,
                 'USER_EMAIL' => self::USER_EMAIL,
                 'USER_NAME' => self::USER_NAME,
+                'INTEGRATION_FEATURES' => self::INTEGRATION_FEATURES,
             ],
             'action' => [
                 'FEATURE' => self::FEATURE,

--- a/tests/Unit/Http/Middleware/RequestLoggingMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/RequestLoggingMiddlewareTest.php
@@ -437,6 +437,252 @@ class RequestLoggingMiddlewareTest extends TestCase
             })
         );
     }
+
+    public function test_integration_features_extracted_via_get_features_method()
+    {
+        $user = new UserWithGetFeatures([
+            'integration-create-as-pending',
+            'integration-skip-validation',
+            'standard-feature',
+        ]);
+
+        $request = Request::create('/api/test', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $this->middleware->handle($request, fn () => new Response('OK', 200));
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ($context['integration_features'] ?? null) === [
+                    'integration-create-as-pending',
+                    'integration-skip-validation',
+                ];
+            })
+        );
+    }
+
+    public function test_integration_features_extracted_via_features_property()
+    {
+        $user = new \stdClass;
+        $user->id = 1;
+        $user->features = [
+            'integration-create-as-pending',
+            'standard-feature',
+            'integration-bypass-stock-check',
+        ];
+
+        $request = Request::create('/api/test', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $this->middleware->handle($request, fn () => new Response('OK', 200));
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ($context['integration_features'] ?? null) === [
+                    'integration-create-as-pending',
+                    'integration-bypass-stock-check',
+                ];
+            })
+        );
+    }
+
+    public function test_integration_features_absent_when_features_empty()
+    {
+        $user = new \stdClass;
+        $user->id = 1;
+        $user->features = [];
+
+        $request = Request::create('/api/test', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $this->middleware->handle($request, fn () => new Response('OK', 200));
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ! array_key_exists('integration_features', $context);
+            })
+        );
+    }
+
+    public function test_integration_features_absent_when_only_non_integration_features()
+    {
+        $user = new \stdClass;
+        $user->id = 1;
+        $user->features = ['standard-feature', 'another-feature'];
+
+        $request = Request::create('/api/test', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $this->middleware->handle($request, fn () => new Response('OK', 200));
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ! array_key_exists('integration_features', $context);
+            })
+        );
+    }
+
+    public function test_integration_features_skips_objects_with_magic_call_and_no_real_get_features()
+    {
+        // Mimics an Eloquent model: __call would route a fictitious getFeatures() to a relation/scope lookup
+        // and throw. method_exists() returns false for magic methods, so we must fall through to property-based
+        // sourcing. Public dynamic property here drives the read.
+        $user = new UserWithMagicCall;
+        $user->features = ['integration-create-as-pending', 'standard-feature'];
+
+        $request = Request::create('/api/test', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $this->middleware->handle($request, fn () => new Response('OK', 200));
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ($context['integration_features'] ?? null) === ['integration-create-as-pending'];
+            })
+        );
+    }
+
+    public function test_integration_features_skips_protected_get_features_method()
+    {
+        // method_exists is true, but is_callable is false from outside-class scope, so we fall through to
+        // property-based sourcing and avoid an \Error from invoking a non-public method.
+        $user = new UserWithProtectedGetFeatures;
+        $user->features = ['integration-bypass-stock-check'];
+
+        $request = Request::create('/api/test', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $this->middleware->handle($request, fn () => new Response('OK', 200));
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ($context['integration_features'] ?? null) === ['integration-bypass-stock-check'];
+            })
+        );
+    }
+
+    public function test_integration_features_skips_protected_get_features_when_magic_call_exists()
+    {
+        // Combined edge case: a class with both __call and a non-public getFeatures(). is_callable() returns
+        // true here (because __call would handle the call), but the reflection-based visibility check rejects
+        // the protected method, so we fall through to the property fallback rather than invoking __call.
+        $user = new UserWithProtectedGetFeaturesAndMagicCall;
+        $user->features = ['integration-create-as-pending'];
+
+        $request = Request::create('/api/test', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $this->middleware->handle($request, fn () => new Response('OK', 200));
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ($context['integration_features'] ?? null) === ['integration-create-as-pending'];
+            })
+        );
+    }
+
+    public function test_integration_features_filters_non_string_and_malformed_entries()
+    {
+        $user = new \stdClass;
+        $user->id = 1;
+        $user->features = [
+            'integration-create-as-pending',
+            123,
+            null,
+            ['nested'],
+            new \stdClass,
+            'integration-bypass-stock-check',
+            'unrelated',
+        ];
+
+        $request = Request::create('/api/test', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $this->middleware->handle($request, fn () => new Response('OK', 200));
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ($context['integration_features'] ?? null) === [
+                    'integration-create-as-pending',
+                    'integration-bypass-stock-check',
+                ];
+            })
+        );
+    }
+}
+
+/**
+ * Test fixture: simulates a user model exposing getFeatures() (e.g. connect-order's ConnectUser).
+ */
+class UserWithGetFeatures
+{
+    public $id = 42;
+
+    private array $features;
+
+    public function __construct(array $features)
+    {
+        $this->features = $features;
+    }
+
+    public function getFeatures(): array
+    {
+        return $this->features;
+    }
+}
+
+/**
+ * Test fixture: simulates an Eloquent-shaped user. __call would handle magic method lookups.
+ * method_exists() must return false for magic, otherwise we'd invoke __call and crash the request.
+ */
+class UserWithMagicCall
+{
+    public $id = 42;
+
+    public ?array $features = null;
+
+    public function __call(string $name, array $arguments)
+    {
+        throw new \BadMethodCallException("Magic call to {$name} would query the database");
+    }
+}
+
+/**
+ * Test fixture: a user model with a protected getFeatures(). method_exists is true but is_callable is false
+ * from outside-class scope. The middleware must skip the call and fall through to the property fallback.
+ */
+class UserWithProtectedGetFeatures
+{
+    public $id = 42;
+
+    public ?array $features = null;
+
+    protected function getFeatures(): array
+    {
+        return ['should-not-be-read'];
+    }
+}
+
+/**
+ * Test fixture: combines protected getFeatures() with __call. PHP's is_callable() returns true here because
+ * __call would handle the invocation, so a visibility check based on is_callable alone is insufficient.
+ * Reflection on the declared method is the only correct guard.
+ */
+class UserWithProtectedGetFeaturesAndMagicCall
+{
+    public $id = 42;
+
+    public ?array $features = null;
+
+    protected function getFeatures(): array
+    {
+        return ['should-not-be-read'];
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        throw new \BadMethodCallException("Magic call to {$name} would crash");
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Make per-tenant `integration-*` features visible on every authenticated request log so triaging integration-token traffic (e.g. `integration-create-as-pending`) becomes a direct ES query instead of an offline JWT decode.
- `RequestLoggingMiddleware::addUserContext()` sources features via a public `getFeatures()` method when present, or a public `$features` property otherwise, filters to the `integration-` prefix, and writes the result under the new `LogFields::INTEGRATION_FEATURES` field. The field is omitted when there are no integration features, so non-integration traffic stays uncluttered.
- Property fallback uses `get_object_vars()` to avoid Eloquent `__isset` magic that would lazy-load a `features` relation. Method check uses `method_exists` plus reflection-based `isPublic()` so it correctly rejects a non-public `getFeatures` even when `__call` is defined (where `is_callable` would falsely return `true` and route the call through `__call`).
- Duck-typed against the consumer's user object (no `JWTUser` shape change). Works for `ConnectUser` shapes that expose `getFeatures()` and shapes that only expose a public `$features` property. New behavior is documented in `docs/logging-integration.md`.

## Review

Internal: 0 findings (additive change, lint clean). External (Codex + Gemini, two rounds): 4 fixes applied, 0 outstanding.
- Round 1: switched property fallback to `get_object_vars()` (avoid Eloquent `__isset` magic) and tightened method check to `method_exists` + `is_callable` (visibility).
- Round 2: tightened further to reflection-based `isPublic()` after Codex flagged that `is_callable` returns `true` for non-public methods when `__call` is defined.
- Each fix has a regression test fixture in the same commit.

## Changes

- `docs/logging-integration.md` (+23): subsection describing the new auto-emitted field and the user-object contract
- `src/Http/Middleware/RequestLoggingMiddleware.php` (+26): `addUserContext()` integration-feature extraction with reflection-guarded method invocation and magic-safe property fallback
- `src/Logging/LogFields.php` (+4): `INTEGRATION_FEATURES` constant
- `tests/Unit/Http/Middleware/RequestLoggingMiddlewareTest.php` (+246): 8 new cases plus 4 fixtures

## Test plan

- [x] 8 new unit tests: `getFeatures()` path, `$features` property path, empty array, non-integration only, mixed types (ints / nulls / nested arrays / objects filtered out), Eloquent-shaped `__call` regression, protected `getFeatures()` regression, protected `getFeatures()` with `__call` regression
- [x] Full PHPUnit suite: 528 passed, 10 skipped (Redis-dependent feature tests, pre-existing)
- [x] Pint clean on changed files
- [ ] Tag pushed and packagist auto-publish confirmed before consumer-service bumps (CON-2024 follow-up PRs in connect-auth, connect-order, connect-product, connect-surplus, connect-processing)

## Backwards compatibility

Purely additive. The change introduces a new optional log field and a new `LogFields` constant. No existing field shapes change. Consuming services do not need to override the middleware to opt in. Services whose user objects expose neither `getFeatures()` nor a public `$features` property simply continue to log without the field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request logs now automatically extract and include user integration features for authenticated users.

* **Documentation**
  * Updated documentation describing automatic integration features extraction in request logging.

* **Tests**
  * Added comprehensive test coverage for integration features extraction across multiple user model scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->