### PR TITLE
docs: add shared types reference and genericize tracing examples

### DIFF
--- a/docs/architecture/shared-types.md
+++ b/docs/architecture/shared-types.md
@@ -1,0 +1,165 @@
+# Shared Types Reference
+
+This document catalogs all shared data structures, value objects, and constants available in `nuimarkets/laravel-shared-utils`.
+
+## Value Objects
+
+### JWTUser
+
+**Location**: `src/Auth/JWTUser.php`
+
+Immutable user object for standardized JWT authentication across services. Replaces ad-hoc `stdClass` usage with type-safe properties.
+
+```php
+class JWTUser
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $org_id,
+        public readonly string $role,       // buyer, seller, admin, machine, etc.
+        public readonly ?string $email = null,
+        public readonly ?string $org_name = null,
+        public readonly ?string $org_type = null,
+    ) {}
+}
+```
+
+**Usage**: Extract from JWT token in authentication middleware, pass to controllers/services.
+
+### SimpleDocument
+
+**Location**: `src/Support/SimpleDocument.php`
+
+JSON API document wrapper that serializes to simple arrays instead of full JSON:API format.
+
+```php
+class SimpleDocument extends Document implements ItemDocumentInterface
+{
+    public function jsonSerialize()
+    // Returns the attributes array, not full JSON:API structure
+}
+```
+
+**Usage**: Request bodies for internal APIs that don't require JSON:API envelope.
+
+## Constants / Enums
+
+### FailureCategory
+
+**Location**: `src/RemoteRepositories/FailureCategory.php`
+
+Constants for classifying remote repository failures. Used by `CachesFailedLookups` trait to determine appropriate cache TTL.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `NOT_FOUND` | `'not_found'` | HTTP 404 - Resource doesn't exist |
+| `AUTH_ERROR` | `'auth_error'` | HTTP 401/403 - Auth/permission failure |
+| `RATE_LIMITED` | `'rate_limited'` | HTTP 429 - Rate limit exceeded |
+| `SERVER_ERROR` | `'server_error'` | HTTP 5xx - Server-side issue |
+| `TIMEOUT` | `'timeout'` | cURL error 28 - Operation timed out |
+| `CONNECTION_ERROR` | `'connection_error'` | DNS/connection failures |
+| `CLIENT_ERROR` | `'client_error'` | Other HTTP 4xx errors |
+| `UNKNOWN` | `'unknown'` | Unclassified failure |
+
+**Transient categories** (may self-resolve): `TIMEOUT`, `CONNECTION_ERROR`, `SERVER_ERROR`, `RATE_LIMITED`
+
+```php
+// Check if a failure is transient
+FailureCategory::isTransient($category); // true for transient categories
+```
+
+## Event Structures
+
+### IntercomEvent
+
+**Location**: `src/Events/IntercomEvent.php`
+
+Laravel event for Intercom analytics tracking with multi-tenant support.
+
+```php
+class IntercomEvent
+{
+    public string $userId;
+    public string $event;
+    public array $properties;
+    public ?string $tenantId;
+}
+```
+
+**Usage**: Dispatch for async Intercom event tracking via `IntercomListener`.
+
+## Request DTOs
+
+### AttachmentUploadRequest
+
+**Location**: `src/Http/Requests/AttachmentUploadRequest.php`
+
+Base form request for file attachments. Services can extend and customize.
+
+**Default validation**:
+- `attachments`: Required array, 1-10 files
+- Each file: Max 10MB, allowed types: jpg, jpeg, png, gif, pdf, doc, docx, xls, xlsx, txt, csv
+- `type`: Optional, one of: image, document, video, text, other
+
+**Extension points**:
+- `getFileValidationRules()` - Customize file constraints
+- `getAllowedMimeTypes()` - Customize file types
+- `getAllowedTypes()` - Customize type categories
+
+## Exception Types
+
+### RemoteServiceException
+
+**Location**: `src/Exceptions/RemoteServiceException.php`
+
+Standard exception for remote service communication failures. Preserves original HTTP status codes.
+
+### CachedLookupFailureException
+
+**Location**: `src/Exceptions/CachedLookupFailureException.php`
+
+Thrown when a cached lookup failure is hit. Provides structured error context.
+
+### BaseHttpRequestException
+
+**Location**: `src/Exceptions/BaseHttpRequestException.php`
+
+Base class for HTTP request exceptions with standardized error handling.
+
+## Abstract Base Classes
+
+### RemoteRepository
+
+**Location**: `src/RemoteRepositories/RemoteRepository.php`
+
+Abstract base for service-to-service API communication.
+
+**Key features**:
+- Lazy token loading (tokens retrieved on first request)
+- X-Ray trace propagation
+- Configurable retry logic
+- URL validation and security checks
+
+See [RemoteRepository.md](../RemoteRepository.md) for full documentation.
+
+## Contracts
+
+### MachineTokenServiceInterface
+
+**Location**: `src/Contracts/MachineTokenServiceInterface.php`
+
+Interface for machine-to-machine authentication token services.
+
+```php
+interface MachineTokenServiceInterface
+{
+    public function getToken(): string;
+}
+```
+
+## Related Documentation
+
+- [RemoteRepository.md](../RemoteRepository.md) - Service-to-service communication
+- [failure-caching.md](../failure-caching.md) - CachesFailedLookups trait
+- [distributed-tracing.md](../distributed-tracing.md) - X-Ray integration
+- [logging-integration.md](../logging-integration.md) - Logging infrastructure

--- a/docs/distributed-tracing.md
+++ b/docs/distributed-tracing.md
@@ -22,7 +22,7 @@ This library provides comprehensive distributed tracing support for Laravel appl
 - **Request ID Propagation** - Continuous request ID tracking across service boundaries
 - **Automatic Header Extraction** - Seamless capture of trace IDs from incoming requests
 - **Service-to-Service Correlation** - Complete request correlation through RemoteRepository calls
-- **CloudWatch Compatibility** - Field naming aligned with connect-cloudwatch-kinesis-to-es processing
+- **CloudWatch Compatibility** - Field naming aligned with downstream log processing
 
 ### Enhanced Debugging
 - **Cross-Service Tracing** - Track requests from API Gateway through entire service chains
@@ -47,7 +47,7 @@ class ServiceRequestLoggingMiddleware extends RequestLoggingMiddleware
 {
     protected function addServiceContext(Request $request, array $context): array
     {
-        $context['service_name'] = 'connect-auth';
+        $context['service_name'] = 'auth-service';
         
         // Add route-specific context
         if ($route = $request->route()) {
@@ -103,12 +103,12 @@ class ProductRepository extends RemoteRepository
 ### Request Flow with Distributed Tracing
 
 ```
-User Request → API Gateway → Service A (connect-auth)
+User Request → API Gateway → Service A (auth-service)
     [X-Amzn-Trace-Id: Root=1-67a92466-..;Parent=...;Sampled=1]
                     ↓ RequestLoggingMiddleware captures trace context
              Logs: request.trace_id, request.amz_trace_id
                     ↓ Business logic processes request
-    Service A → API Gateway → Service B (connect-product)
+    Service A → API Gateway → Service B (product-service)
     [X-Amzn-Trace-Id: Root=1-67a92466-..;Parent=NEW;Sampled=1]
                     ↓ X-Ray automatically links as parent-child
              Complete trace chain maintained ✅
@@ -168,7 +168,7 @@ Log::info('Processing order', [
 ### Service-to-Service Calls
 
 ```php
-// In connect-auth service
+// In auth-service
 class OrderService
 {
     public function processOrder($orderData)
@@ -184,7 +184,7 @@ class OrderService
     }
 }
 
-// In connect-product service (different service, same trace)
+// In product-service (different service, same trace)
 class ProductController
 {
     public function getProducts(Request $request)
@@ -202,7 +202,7 @@ class ProductController
 ### Error Correlation Across Services
 
 ```php
-// When an error occurs in connect-product
+// When an error occurs in product-service
 try {
     $products = $this->productService->getProducts($ids);
 } catch (Exception $e) {
@@ -212,7 +212,7 @@ try {
     ]);
     
     // Error logs automatically include trace context
-    // Can be correlated with original request in connect-auth
+    // Can be correlated with original request in auth-service
     throw new RemoteServiceException('Product service unavailable');
 }
 ```
@@ -319,7 +319,7 @@ class ProductRepository extends RemoteRepository
 
 #### Step 4: Update Log Processing
 ```php
-// connect-cloudwatch-kinesis-to-es TOP_LEVEL_FIELDS
+// Log processor TOP_LEVEL_FIELDS config
 // Add new fields to promote to root level:
 "request.trace_id",
 "request.amz_trace_id"
@@ -356,7 +356,7 @@ Include trace context in error logs for easier debugging:
 
 ```php
 Log::error('Service unavailable', [
-    'service' => 'connect-product',
+    'service' => 'product-service',
     'endpoint' => '/v1/products',
     'error' => $exception->getMessage()
 ]);


### PR DESCRIPTION
## Summary

- Add `docs/architecture/shared-types.md` cataloging value objects (JWTUser, SimpleDocument), FailureCategory constants, event/request DTOs, exceptions, and contracts so consuming services have one place to look up types they import from this package
- Genericize platform-specific service names in `distributed-tracing.md` (`connect-auth`, `connect-product`, `connect-cloudwatch-kinesis-to-es`) to generic equivalents (`auth-service`, `product-service`, "log processor"), per CLAUDE.md mandate that this library's docs remain consumer-agnostic

## Review

Internal: 2 auto-fixed (JWTUser constructor-promoted form, SimpleDocument signature accuracy).
External (Gemini): 1 auto-fixed (removed platform-specific service table to comply with CLAUDE.md generic-only mandate).
Post-push: 8 additional Connect-specific service refs genericized in distributed-tracing.md (lines 25, 50, 106, 111, 171, 187, 205, 215, 322, 359).

## Changes

```
docs/architecture/shared-types.md | 165 ++++++++++++++++++++++++++++++++++++++
docs/distributed-tracing.md       |  20 ++---
2 files changed, 175 insertions(+), 10 deletions(-)
```

## Test plan

- [x] Verified shared-types.md cross-links resolve to existing docs in this repo
- [x] Source verified: JWTUser, SimpleDocument, FailureCategory, IntercomEvent, AttachmentUploadRequest, MachineTokenServiceInterface paths/signatures/properties all match `src/`
- [x] No platform-specific service names in new content (CLAUDE.md generic-only mandate)
- [x] Confirmed `grep -n "connect-" docs/distributed-tracing.md` returns no matches after edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new architecture reference cataloging shared types, value objects, enums, request DTOs, exception types, service contracts, usage notes, and cross-references to related architecture guides.
  * Clarified distributed tracing docs: reworded a CloudWatch compatibility item and updated a migration step to reference a generic top-level log-fields configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuimarkets/nui-laravel-shared-utils/pull/95)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->