### PR TITLE
feat(http): add IdempotencyMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Comprehensive health checks for MySQL, PostgreSQL, Redis, storage, cache, and PH
 
 Enhanced RemoteRepository with lazy token loading for optimal performance, retry logic, automatic JWT authentication, and proper HTTP status propagation.
 
+### **Idempotency Middleware**
+
+Opt-in write-request idempotency for retry-safe endpoints. Supports
+`Idempotency-Key` headers, a short-lived body-hash fallback, Redis-backed
+inflight locks, response replay, and conflict detection when a key is reused
+for different request content.
+
 ### **Failure Caching**
 
 Intelligent caching of remote service failures to prevent cascading timeouts during outages. HTTP status-aware TTLs cache 404s longer than transient errors like timeouts. Includes failure classification, configurable per-category TTLs, and convenience methods for handling cached failures gracefully.
@@ -106,6 +113,7 @@ php artisan vendor:publish --tag=intercom-config
 | **Distributed Tracing** | AWS X-Ray integration with request correlation | [Guide](docs/distributed-tracing.md) |
 | **Logging System** | Enhanced logging with Elasticsearch routing | [Guide](docs/logging-integration.md) |
 | **RemoteRepository** | Service-to-service communication framework | [Guide](docs/RemoteRepository.md) |
+| **Idempotency Middleware** | Retry-safe write endpoints with response replay | [Guide](docs/idempotency.md) |
 | **Failure Caching** | Cache remote failures to prevent cascading timeouts | [Guide](docs/failure-caching.md) |
 | **JSON API Validation** | Standardized error handling with unified formatting | [Guide](docs/json-api-validation.md) |
 | **Intercom Integration** | User analytics and event tracking | [Guide](docs/intercom-integration.md) |

--- a/config/idempotency.php
+++ b/config/idempotency.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'enabled' => env('IDEMPOTENCY_ENABLED', false),
+    'redis_connection' => env('IDEMPOTENCY_REDIS_CONNECTION', 'default'),
+    'key_prefix' => env('IDEMPOTENCY_KEY_PREFIX', 'idem:v1'),
+    'ttl_header' => env('IDEMPOTENCY_TTL_HEADER', 600),
+    'ttl_body_hash' => env('IDEMPOTENCY_TTL_BODY_HASH', 30),
+    'lock_ttl' => env('IDEMPOTENCY_LOCK_TTL', 60),
+    'header_name' => env('IDEMPOTENCY_HEADER_NAME', 'Idempotency-Key'),
+    'header_max_length' => env('IDEMPOTENCY_HEADER_MAX_LENGTH', 255),
+    'retry_after_seconds' => env('IDEMPOTENCY_RETRY_AFTER_SECONDS', 5),
+    'max_response_bytes' => env('IDEMPOTENCY_MAX_RESPONSE_BYTES', 262144),
+    'replayable_status_codes' => [200, 201, 202, 204, 422],
+    'replayable_content_types' => [
+        'application/json',
+        'application/vnd.api+json',
+        'text/plain',
+    ],
+    'replay_headers_allowlist' => [
+        'content-type',
+        'cache-control',
+        'etag',
+        'location',
+    ],
+    'body_hash_skip_content_types' => [
+        'multipart/form-data',
+        'application/octet-stream',
+    ],
+];

--- a/config/idempotency.php
+++ b/config/idempotency.php
@@ -12,6 +12,7 @@ return [
     'retry_after_seconds' => env('IDEMPOTENCY_RETRY_AFTER_SECONDS', 5),
     'max_response_bytes' => env('IDEMPOTENCY_MAX_RESPONSE_BYTES', 262144),
     'replayable_status_codes' => [200, 201, 202, 204, 422],
+    'no_body_status_codes' => [204],
     'replayable_content_types' => [
         'application/json',
         'application/vnd.api+json',

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -1,0 +1,308 @@
+# Idempotency Middleware
+
+## Overview
+
+`IdempotencyMiddleware` lets write endpoints safely replay completed
+responses when a caller retries the same request. It is designed for POST,
+PUT, PATCH, and DELETE routes where a network timeout or gateway retry could
+otherwise create duplicate records or repeat side effects.
+
+The middleware supports two key strategies:
+
+- Caller-provided `Idempotency-Key` headers for clients that can generate
+  stable retry keys.
+- A short-lived body-hash fallback for clients that retry byte-identical
+  requests without sending a key.
+
+The middleware is opt-in. Applications register the service provider, publish
+config if they need overrides, and attach the middleware only to routes that
+should use this contract.
+
+## Installation
+
+Register the provider in the consuming application:
+
+```php
+// config/app.php
+'providers' => [
+    NuiMarkets\LaravelSharedUtils\Providers\IdempotencyServiceProvider::class,
+],
+```
+
+Publish the config when local overrides are needed:
+
+```bash
+php artisan vendor:publish --tag=idempotency-config
+```
+
+Attach the middleware to selected routes or route groups:
+
+```php
+use NuiMarkets\LaravelSharedUtils\Http\Middleware\IdempotencyMiddleware;
+
+Route::post('/orders', [OrderController::class, 'store'])
+    ->middleware(IdempotencyMiddleware::class);
+```
+
+Enable it through configuration:
+
+```bash
+IDEMPOTENCY_ENABLED=true
+IDEMPOTENCY_REDIS_CONNECTION=default
+```
+
+## Request Contract
+
+### Header Path
+
+Clients should send an `Idempotency-Key` header for retryable write requests:
+
+```http
+POST /orders HTTP/1.1
+Content-Type: application/json
+Idempotency-Key: 4c03a6e8-13be-4d47-861f-d79b312bc880
+```
+
+Header keys must be printable ASCII, non-empty after trimming, contain no
+whitespace or control characters, and fit within `header_max_length`.
+
+Invalid keys return `400 idempotency_key_invalid`. The middleware does not
+fall back to body hashing when a malformed header is present, because the
+caller attempted to use the explicit idempotency contract.
+
+### Body-Hash Fallback
+
+When the header is absent, the middleware can synthesize a key from:
+
+- authenticated actor scope
+- HTTP method
+- route identity
+- raw request body hash
+
+The body hash uses raw request bytes. JSON is not normalized. Retried requests
+must send byte-identical bodies to replay.
+
+Body-hash entries use a shorter TTL by default because they are intended to
+catch rapid retries from systems that cannot send an idempotency header.
+
+### Content-Type Skips
+
+If no `Idempotency-Key` header is present, configured upload-style request
+content types are skipped by default:
+
+- `multipart/form-data`
+- `application/octet-stream`
+
+If a valid `Idempotency-Key` header is present, the header path still runs
+even for these request content types.
+
+## Cache Identity
+
+The Redis key does not store raw user IDs, organization IDs, route data, or
+caller-provided idempotency keys. Components are joined with an ASCII unit
+separator and hashed.
+
+The cache identity includes:
+
+- actor scope, including organization ID when available
+- HTTP method
+- route name plus sorted route parameters, when a named route exists
+- normalized query string
+- caller-provided idempotency key, or synthesized body-hash key
+
+The stored fingerprint includes the actor scope, method, route identity, and
+raw request body hash. Reusing the same `Idempotency-Key` for the same actor,
+method, route identity, and query string with a different body returns
+`422 idempotency_key_conflict`.
+
+Changing the route, query string, actor, or organization changes the Redis key
+scope. Those requests do not replay each other.
+
+## Cached Responses
+
+Only configured replayable status codes are cached. Defaults:
+
+```php
+[200, 201, 202, 204, 422]
+```
+
+The cached payload stores:
+
+```json
+{
+  "status": 201,
+  "headers": {
+    "content-type": "application/json",
+    "location": "/orders/123"
+  },
+  "body_b64": "eyJpZCI6IjEyMyJ9",
+  "fingerprint": "sha256-hex",
+  "state": "complete",
+  "completed_at": 1778544000,
+  "locked_at": 1778543999
+}
+```
+
+Response bodies are base64 encoded before storage so arbitrary bytes can
+round-trip through JSON. The `max_response_bytes` limit applies to the raw
+response body before base64 expansion.
+
+### Header Replay
+
+Only allowlisted response headers are stored and replayed. Defaults:
+
+```php
+[
+    'content-type',
+    'cache-control',
+    'etag',
+    'location',
+]
+```
+
+`Location` is included so `201 Created` responses can replay the created
+resource URL.
+
+The middleware adds these headers to replayed responses:
+
+```http
+X-Idempotency-Replay: 1
+X-Idempotency-Original-Status: 201
+```
+
+Middleware-generated error responses, including 400, 409, and 422 responses,
+and replay responses receive `Cache-Control: no-store` unless that directive is
+already present.
+
+### No-Body Responses
+
+Configured no-body statuses can be cached without a `Content-Type` header when
+the response body is empty. Default:
+
+```php
+'no_body_status_codes' => [204],
+```
+
+Responses with a body, or with statuses outside this list, still need a
+replayable content type.
+
+## Inflight Requests
+
+The first matching request writes an inflight lock to Redis using `SET NX`
+with `lock_ttl`.
+
+If a duplicate request arrives while the first request is still processing,
+the middleware returns:
+
+```http
+409 Conflict
+Retry-After: 5
+Cache-Control: no-store
+```
+
+`Retry-After` is computed from the remaining lock TTL when the inflight payload
+is readable. It falls back to `retry_after_seconds` otherwise.
+
+Completed payloads are written in a Laravel terminating callback. If the lock
+expires before the callback runs, the middleware logs
+`idempotency.lock_expired_before_complete` and skips the stale write.
+
+Set `lock_ttl` higher than the worst-case controller execution time for
+protected routes. If a controller can legitimately run longer than 60 seconds,
+raise `IDEMPOTENCY_LOCK_TTL`.
+
+## Error Responses
+
+Plain JSON is used by default:
+
+```json
+{
+  "error": "idempotency_key_conflict",
+  "message": "The idempotency key was already used for a different request."
+}
+```
+
+When the request `Accept` header includes `application/vnd.api+json`, JSON:API
+error shape is used:
+
+```json
+{
+  "errors": [
+    {
+      "status": "422",
+      "code": "idempotency_key_conflict",
+      "title": "Idempotency Key Conflict",
+      "detail": "The idempotency key was already used for a different request."
+    }
+  ]
+}
+```
+
+## Configuration Reference
+
+```php
+return [
+    'enabled' => env('IDEMPOTENCY_ENABLED', false),
+    'redis_connection' => env('IDEMPOTENCY_REDIS_CONNECTION', 'default'),
+    'key_prefix' => env('IDEMPOTENCY_KEY_PREFIX', 'idem:v1'),
+    'ttl_header' => env('IDEMPOTENCY_TTL_HEADER', 600),
+    'ttl_body_hash' => env('IDEMPOTENCY_TTL_BODY_HASH', 30),
+    'lock_ttl' => env('IDEMPOTENCY_LOCK_TTL', 60),
+    'header_name' => env('IDEMPOTENCY_HEADER_NAME', 'Idempotency-Key'),
+    'header_max_length' => env('IDEMPOTENCY_HEADER_MAX_LENGTH', 255),
+    'retry_after_seconds' => env('IDEMPOTENCY_RETRY_AFTER_SECONDS', 5),
+    'max_response_bytes' => env('IDEMPOTENCY_MAX_RESPONSE_BYTES', 262144),
+    'replayable_status_codes' => [200, 201, 202, 204, 422],
+    'no_body_status_codes' => [204],
+    'replayable_content_types' => [
+        'application/json',
+        'application/vnd.api+json',
+        'text/plain',
+    ],
+    'replay_headers_allowlist' => [
+        'content-type',
+        'cache-control',
+        'etag',
+        'location',
+    ],
+    'body_hash_skip_content_types' => [
+        'multipart/form-data',
+        'application/octet-stream',
+    ],
+];
+```
+
+## Logging
+
+The middleware logs these events:
+
+- `idempotency.lock_acquired`
+- `idempotency.replay`
+- `idempotency.conflict`
+- `idempotency.inflight_reject`
+- `idempotency.fail_open`
+- `idempotency.skip_cache`
+- `idempotency.lock_expired_before_complete`
+
+Skip cache logs include `skip_reason`:
+
+- `streamed`
+- `oversize`
+- `content_type`
+- `status_code`
+
+Redis errors fail open. The request continues through the application and the
+middleware logs `idempotency.fail_open`.
+
+## Testing
+
+The package includes unit and feature coverage for the middleware:
+
+```bash
+composer test IdempotencyMiddleware
+```
+
+The test suite includes coverage for header replay, body-hash fallback, route
+and query scoping, invalid keys, conflicts, inflight rejection, 201 `Location`
+replay, 204 no-content replay, binary body round-trips, and Redis fail-open
+behavior.

--- a/src/Http/Middleware/IdempotencyMiddleware.php
+++ b/src/Http/Middleware/IdempotencyMiddleware.php
@@ -1,0 +1,499 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response as IlluminateResponse;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Redis;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
+
+class IdempotencyMiddleware
+{
+    private const SEPARATOR = "\x1f";
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! config('idempotency.enabled', false)) {
+            return $next($request);
+        }
+
+        $user = $request->user();
+        if ($user === null || ! $this->isWriteMethod($request->method())) {
+            return $next($request);
+        }
+
+        $userId = $this->getUserId($user);
+        if ($userId === null || $userId === '') {
+            return $next($request);
+        }
+
+        $headerName = (string) config('idempotency.header_name', 'Idempotency-Key');
+        $hasHeader = $request->headers->has($headerName);
+
+        if (! $hasHeader && $this->requestContentTypeMatches($request, config('idempotency.body_hash_skip_content_types', []))) {
+            return $next($request);
+        }
+
+        $actorScope = $this->actorScope($userId, $this->getOrgId($user));
+        $method = strtoupper($request->method());
+        $routeIdentity = $this->routeIdentity($request);
+        $requestBody = $request->getContent();
+        $bodyHash = hash('sha256', $requestBody === false ? '' : $requestBody);
+
+        $resolved = $this->resolveKey($request, $hasHeader, $headerName, $actorScope, $method, $routeIdentity, $bodyHash);
+        if ($resolved['error'] !== null) {
+            return $this->errorResponse($request, 400, 'idempotency_key_invalid', $resolved['error']);
+        }
+
+        $source = $resolved['source'];
+        $fingerprint = $this->fingerprint($actorScope, $method, $routeIdentity, $bodyHash);
+        $cacheKey = $this->cacheKey($source, $actorScope, $method, $routeIdentity, $resolved['key']);
+        $lockTtl = (int) config('idempotency.lock_ttl', 60);
+        $lockedAt = $this->now();
+
+        try {
+            $connection = Redis::connection((string) config('idempotency.redis_connection', 'default'));
+            $lockAcquired = $connection->set($cacheKey, json_encode([
+                'fingerprint' => $fingerprint,
+                'state' => 'inflight',
+                'locked_at' => $lockedAt,
+            ]), 'EX', $lockTtl, 'NX');
+        } catch (Throwable $e) {
+            $this->log('warning', 'idempotency.fail_open', $source, $cacheKey, $fingerprint, [
+                'exception' => get_class($e),
+                'message' => $e->getMessage(),
+            ]);
+
+            return $next($request);
+        }
+
+        if ($lockAcquired) {
+            $this->log('info', 'idempotency.lock_acquired', $source, $cacheKey, $fingerprint);
+
+            $response = $next($request);
+
+            App::terminating(function () use ($connection, $cacheKey, $fingerprint, $source, $response, $lockedAt, $lockTtl, $resolved): void {
+                $this->complete($connection, $cacheKey, $fingerprint, $source, $response, $lockedAt, $lockTtl, $resolved['ttl']);
+            });
+
+            return $response;
+        }
+
+        try {
+            $existing = $this->decodePayload($connection->get($cacheKey));
+        } catch (Throwable $e) {
+            $this->log('warning', 'idempotency.fail_open', $source, $cacheKey, $fingerprint, [
+                'exception' => get_class($e),
+                'message' => $e->getMessage(),
+            ]);
+
+            return $next($request);
+        }
+
+        if (! $this->isReadablePayload($existing)) {
+            $this->log('warning', 'idempotency.fail_open', $source, $cacheKey, $fingerprint);
+
+            return $next($request);
+        }
+
+        if (($existing['fingerprint'] ?? null) !== $fingerprint) {
+            $this->log('info', 'idempotency.conflict', $source, $cacheKey, $fingerprint);
+
+            return $this->errorResponse(
+                $request,
+                422,
+                'idempotency_key_conflict',
+                'The idempotency key was already used for a different request.'
+            );
+        }
+
+        if (($existing['state'] ?? null) === 'inflight') {
+            if ($this->inflightExpired($existing, $lockTtl)) {
+                try {
+                    $connection->del($cacheKey);
+                } catch (Throwable $e) {
+                    $this->log('warning', 'idempotency.fail_open', $source, $cacheKey, $fingerprint, [
+                        'exception' => get_class($e),
+                        'message' => $e->getMessage(),
+                    ]);
+                }
+
+                return $next($request);
+            }
+
+            $retryAfter = $this->retryAfter($existing, $lockTtl);
+            $this->log('info', 'idempotency.inflight_reject', $source, $cacheKey, $fingerprint);
+
+            return $this->errorResponse(
+                $request,
+                409,
+                'idempotency_request_inflight',
+                'A request with this idempotency key is still being processed.',
+                ['Retry-After' => (string) $retryAfter]
+            );
+        }
+
+        if (($existing['state'] ?? null) === 'complete' && $this->isCompletePayload($existing)) {
+            $this->log('info', 'idempotency.replay', $source, $cacheKey, $fingerprint);
+
+            return $this->replayResponse($existing);
+        }
+
+        $this->log('warning', 'idempotency.fail_open', $source, $cacheKey, $fingerprint);
+
+        return $next($request);
+    }
+
+    protected function now(): int
+    {
+        return now()->getTimestamp();
+    }
+
+    private function complete($connection, string $cacheKey, string $fingerprint, string $source, Response $response, int $lockedAt, int $lockTtl, int $ttl): void
+    {
+        try {
+            $existing = $this->decodePayload($connection->get($cacheKey));
+
+            if (
+                ! is_array($existing)
+                || ($existing['state'] ?? null) !== 'inflight'
+                || ($existing['fingerprint'] ?? null) !== $fingerprint
+                || (int) ($existing['locked_at'] ?? 0) !== $lockedAt
+                || $this->now() > ($lockedAt + $lockTtl)
+            ) {
+                $this->log('warning', 'idempotency.lock_expired_before_complete', $source, $cacheKey, $fingerprint);
+
+                return;
+            }
+
+            $skipReason = $this->skipReason($response);
+            if ($skipReason !== null) {
+                $connection->del($cacheKey);
+                $this->log('info', 'idempotency.skip_cache', $source, $cacheKey, $fingerprint, [
+                    'skip_reason' => $skipReason,
+                ]);
+
+                return;
+            }
+
+            $responseBody = $response->getContent();
+
+            $connection->set($cacheKey, json_encode([
+                'status' => $response->getStatusCode(),
+                'headers' => $this->headersForStorage($response),
+                'body_b64' => base64_encode($responseBody === false ? '' : $responseBody),
+                'fingerprint' => $fingerprint,
+                'state' => 'complete',
+                'completed_at' => $this->now(),
+                'locked_at' => $lockedAt,
+            ]), 'EX', $ttl);
+        } catch (Throwable $e) {
+            $this->log('warning', 'idempotency.fail_open', $source, $cacheKey, $fingerprint, [
+                'exception' => get_class($e),
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function resolveKey(Request $request, bool $hasHeader, string $headerName, string $actorScope, string $method, string $routeIdentity, string $bodyHash): array
+    {
+        if ($hasHeader) {
+            $key = trim((string) $request->headers->get($headerName, ''));
+            $maxLength = (int) config('idempotency.header_max_length', 255);
+
+            if ($key === '') {
+                return ['error' => 'The idempotency key must not be empty.'];
+            }
+
+            if (strlen($key) > $maxLength) {
+                return ['error' => "The idempotency key must not exceed {$maxLength} characters."];
+            }
+
+            if (! preg_match('/^[\x21-\x7e]+$/', $key)) {
+                return ['error' => 'The idempotency key must contain only printable ASCII characters with no whitespace.'];
+            }
+
+            return [
+                'error' => null,
+                'key' => $key,
+                'source' => 'header',
+                'ttl' => (int) config('idempotency.ttl_header', 600),
+            ];
+        }
+
+        return [
+            'error' => null,
+            'key' => $this->join([$actorScope, $method, $routeIdentity, $bodyHash]),
+            'source' => 'body_hash',
+            'ttl' => (int) config('idempotency.ttl_body_hash', 30),
+        ];
+    }
+
+    private function cacheKey(string $source, string $actorScope, string $method, string $routeIdentity, string $resolvedKey): string
+    {
+        $digest = hash('sha256', $this->join([$actorScope, $method, $routeIdentity, $resolvedKey]));
+
+        return rtrim((string) config('idempotency.key_prefix', 'idem:v1'), ':').':'.$source.':'.$digest;
+    }
+
+    private function fingerprint(string $actorScope, string $method, string $routeIdentity, string $bodyHash): string
+    {
+        return hash('sha256', $this->join([$actorScope, $method, $routeIdentity, $bodyHash]));
+    }
+
+    private function join(array $components): string
+    {
+        return implode(self::SEPARATOR, array_map(static fn ($value): string => (string) $value, $components));
+    }
+
+    private function actorScope(string $userId, ?string $orgId): string
+    {
+        return $this->join(['user', $userId, 'org', $orgId ?? '']);
+    }
+
+    private function routeIdentity(Request $request): string
+    {
+        $route = $request->route();
+
+        if ($route && $route->getName()) {
+            $parameters = $route->parameters();
+            ksort($parameters);
+
+            return $this->join(['route', $route->getName(), $this->stableJson($parameters)]);
+        }
+
+        return $this->join(['path', '/'.ltrim($request->path(), '/'), $this->normalizedQuery($request->query())]);
+    }
+
+    private function normalizedQuery(array $query): string
+    {
+        $this->recursiveKsort($query);
+
+        return $this->stableJson($query);
+    }
+
+    private function recursiveKsort(array &$value): void
+    {
+        ksort($value);
+
+        foreach ($value as &$child) {
+            if (is_array($child)) {
+                $this->recursiveKsort($child);
+            }
+        }
+    }
+
+    private function stableJson($value): string
+    {
+        return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+
+    private function getUserId($user): ?string
+    {
+        $id = $user->id ?? null;
+
+        if ($id === null && method_exists($user, 'getAuthIdentifier')) {
+            $id = $user->getAuthIdentifier();
+        }
+
+        if ($id === null && method_exists($user, 'getKey')) {
+            $id = $user->getKey();
+        }
+
+        return $id === null ? null : (string) $id;
+    }
+
+    private function getOrgId($user): ?string
+    {
+        $id = $user->org_id ?? $user->organization_id ?? $user->organisation_id ?? null;
+
+        return $id === null ? null : (string) $id;
+    }
+
+    private function isWriteMethod(string $method): bool
+    {
+        return in_array(strtoupper($method), ['POST', 'PATCH', 'PUT', 'DELETE'], true);
+    }
+
+    private function requestContentTypeMatches(Request $request, array $contentTypes): bool
+    {
+        return $this->contentTypeMatches((string) $request->headers->get('Content-Type', ''), $contentTypes);
+    }
+
+    private function contentTypeMatches(string $actual, array $allowed): bool
+    {
+        $actual = strtolower(trim(explode(';', $actual)[0]));
+
+        if ($actual === '') {
+            return false;
+        }
+
+        foreach ($allowed as $contentType) {
+            if ($actual === strtolower((string) $contentType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function skipReason(Response $response): ?string
+    {
+        if ($response instanceof StreamedResponse || $response instanceof BinaryFileResponse) {
+            return 'streamed';
+        }
+
+        if (! in_array($response->getStatusCode(), config('idempotency.replayable_status_codes', []), true)) {
+            return 'status_code';
+        }
+
+        $content = $response->getContent();
+        if ($content === false) {
+            return 'streamed';
+        }
+
+        if (strlen($content) > (int) config('idempotency.max_response_bytes', 262144)) {
+            return 'oversize';
+        }
+
+        if (! $this->contentTypeMatches((string) $response->headers->get('Content-Type', ''), config('idempotency.replayable_content_types', []))) {
+            return 'content_type';
+        }
+
+        return null;
+    }
+
+    private function headersForStorage(Response $response): array
+    {
+        $headers = [];
+
+        foreach (config('idempotency.replay_headers_allowlist', []) as $header) {
+            $value = $response->headers->get((string) $header);
+            if ($value !== null) {
+                $headers[strtolower((string) $header)] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
+    private function decodePayload($payload): ?array
+    {
+        if (! is_string($payload) || $payload === '') {
+            return null;
+        }
+
+        $decoded = json_decode($payload, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function isReadablePayload(?array $payload): bool
+    {
+        return is_array($payload)
+            && isset($payload['fingerprint'])
+            && isset($payload['state']);
+    }
+
+    private function isCompletePayload(array $payload): bool
+    {
+        return isset($payload['status'], $payload['body_b64'])
+            && is_numeric($payload['status'])
+            && base64_decode((string) $payload['body_b64'], true) !== false;
+    }
+
+    private function inflightExpired(array $payload, int $lockTtl): bool
+    {
+        if (! isset($payload['locked_at']) || ! is_numeric($payload['locked_at'])) {
+            return false;
+        }
+
+        return $this->now() >= ((int) $payload['locked_at'] + $lockTtl);
+    }
+
+    private function retryAfter(array $payload, int $lockTtl): int
+    {
+        if (isset($payload['locked_at']) && is_numeric($payload['locked_at'])) {
+            return max(1, ((int) $payload['locked_at'] + $lockTtl) - $this->now());
+        }
+
+        return (int) config('idempotency.retry_after_seconds', 5);
+    }
+
+    private function replayResponse(array $payload): Response
+    {
+        $headers = $payload['headers'] ?? [];
+        $headers['X-Idempotency-Replay'] = '1';
+        $headers['X-Idempotency-Original-Status'] = (string) $payload['status'];
+
+        $response = new IlluminateResponse(
+            base64_decode((string) $payload['body_b64']),
+            (int) $payload['status'],
+            $headers
+        );
+
+        $this->addNoStore($response);
+
+        return $response;
+    }
+
+    private function errorResponse(Request $request, int $status, string $code, string $message, array $headers = []): Response
+    {
+        if ($this->wantsJsonApi($request)) {
+            $body = [
+                'errors' => [[
+                    'status' => (string) $status,
+                    'code' => $code,
+                    'title' => $this->titleFromCode($code),
+                    'detail' => $message,
+                ]],
+            ];
+        } else {
+            $body = [
+                'error' => $code,
+                'message' => $message,
+            ];
+        }
+
+        $response = response()->json($body, $status, $headers);
+        $this->addNoStore($response);
+
+        return $response;
+    }
+
+    private function wantsJsonApi(Request $request): bool
+    {
+        return str_contains((string) $request->headers->get('Accept', ''), 'application/vnd.api+json');
+    }
+
+    private function titleFromCode(string $code): string
+    {
+        return ucwords(str_replace('_', ' ', $code));
+    }
+
+    private function addNoStore(Response $response): void
+    {
+        $cacheControl = (string) $response->headers->get('Cache-Control', '');
+
+        if (! str_contains(strtolower($cacheControl), 'no-store')) {
+            $response->headers->set('Cache-Control', 'no-store');
+        }
+    }
+
+    private function log(string $level, string $event, string $source, string $cacheKey, string $fingerprint, array $context = []): void
+    {
+        Log::{$level}($event, array_merge([
+            'event' => $event,
+            'idempotency_key_source' => $source,
+            'cache_key' => $cacheKey,
+            'fingerprint' => $fingerprint,
+            'request_id' => request()?->headers->get('X-Request-ID'),
+        ], $context));
+    }
+}

--- a/src/Http/Middleware/IdempotencyMiddleware.php
+++ b/src/Http/Middleware/IdempotencyMiddleware.php
@@ -265,7 +265,7 @@ class IdempotencyMiddleware
             $parameters = $route->parameters();
             ksort($parameters);
 
-            return $this->join(['route', $route->getName(), $this->stableJson($parameters)]);
+            return $this->join(['route', $route->getName(), $this->stableJson($parameters), $this->normalizedQuery($request->query())]);
         }
 
         return $this->join(['path', '/'.ltrim($request->path(), '/'), $this->normalizedQuery($request->query())]);
@@ -354,6 +354,10 @@ class IdempotencyMiddleware
         }
 
         $content = $response->getContent();
+        if (($content === false || $content === '') && in_array($response->getStatusCode(), config('idempotency.no_body_status_codes', [204]), true)) {
+            return null;
+        }
+
         if ($content === false) {
             return 'streamed';
         }

--- a/src/Providers/IdempotencyServiceProvider.php
+++ b/src/Providers/IdempotencyServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class IdempotencyServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../config/idempotency.php', 'idempotency');
+    }
+
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../../config/idempotency.php' => config_path('idempotency.php'),
+            ], 'idempotency-config');
+        }
+    }
+}

--- a/tests/Feature/IdempotencyMiddlewareTest.php
+++ b/tests/Feature/IdempotencyMiddlewareTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Feature;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Route;
+use NuiMarkets\LaravelSharedUtils\Auth\JWTUser;
+use NuiMarkets\LaravelSharedUtils\Http\Middleware\IdempotencyMiddleware;
+use NuiMarkets\LaravelSharedUtils\Providers\IdempotencyServiceProvider;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use NuiMarkets\LaravelSharedUtils\Tests\Utils\FakeRedisConnection;
+
+class IdempotencyMiddlewareTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            IdempotencyServiceProvider::class,
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('idempotency.enabled', true);
+        Redis::swap(new class(new FakeRedisConnection)
+        {
+            public function __construct(private FakeRedisConnection $connection) {}
+
+            public function connection(string $name = 'default'): FakeRedisConnection
+            {
+                return $this->connection;
+            }
+        });
+
+        $this->app->instance('idempotency.calls', 0);
+
+        Route::post('/idempotent', function () {
+            $this->app->instance('idempotency.calls', $this->app->make('idempotency.calls') + 1);
+
+            return response()->json(['calls' => $this->app->make('idempotency.calls')]);
+        })->middleware([AuthenticateIdempotencyTestUser::class, IdempotencyMiddleware::class]);
+
+        Route::post('/idempotent-validation', function () {
+            $this->app->instance('idempotency.calls', $this->app->make('idempotency.calls') + 1);
+
+            return response()->json(['error' => 'invalid', 'calls' => $this->app->make('idempotency.calls')], 422);
+        })->middleware([AuthenticateIdempotencyTestUser::class, IdempotencyMiddleware::class]);
+    }
+
+    public function test_stub_route_replays_without_invoking_controller_again(): void
+    {
+        $first = $this->postJson('/idempotent', ['product' => 'beef'], ['Idempotency-Key' => 'feature-key']);
+        $this->app->terminate();
+
+        $second = $this->postJson('/idempotent', ['product' => 'beef'], ['Idempotency-Key' => 'feature-key']);
+
+        $first->assertOk()->assertJson(['calls' => 1]);
+        $second->assertOk()->assertHeader('X-Idempotency-Replay', '1')->assertJson(['calls' => 1]);
+        $this->assertSame(1, $this->app->make('idempotency.calls'));
+    }
+
+    public function test_422_route_replays_without_invoking_controller_again(): void
+    {
+        $first = $this->postJson('/idempotent-validation', ['product' => 'beef'], ['Idempotency-Key' => 'feature-422']);
+        $this->app->terminate();
+
+        $second = $this->postJson('/idempotent-validation', ['product' => 'beef'], ['Idempotency-Key' => 'feature-422']);
+
+        $first->assertStatus(422)->assertJson(['calls' => 1]);
+        $second->assertStatus(422)->assertHeader('X-Idempotency-Replay', '1')->assertJson(['calls' => 1]);
+        $this->assertSame(1, $this->app->make('idempotency.calls'));
+    }
+}
+
+class AuthenticateIdempotencyTestUser
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $request->setUserResolver(fn () => new JWTUser('feature-user', 'feature-org', 'buyer'));
+
+        return $next($request);
+    }
+}

--- a/tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php
@@ -22,8 +22,35 @@ class IdempotencyMiddlewareTest extends TestCase
         parent::setUp();
 
         Carbon::setTestNow(Carbon::create(2026, 5, 12, 12, 0, 0));
-        config()->set('idempotency', require __DIR__.'/../../../../config/idempotency.php');
-        config()->set('idempotency.enabled', true);
+        config()->set('idempotency', [
+            'enabled' => true,
+            'redis_connection' => 'default',
+            'key_prefix' => 'idem:v1',
+            'ttl_header' => 600,
+            'ttl_body_hash' => 30,
+            'lock_ttl' => 60,
+            'header_name' => 'Idempotency-Key',
+            'header_max_length' => 255,
+            'retry_after_seconds' => 5,
+            'max_response_bytes' => 262144,
+            'replayable_status_codes' => [200, 201, 202, 204, 422],
+            'no_body_status_codes' => [204],
+            'replayable_content_types' => [
+                'application/json',
+                'application/vnd.api+json',
+                'text/plain',
+            ],
+            'replay_headers_allowlist' => [
+                'content-type',
+                'cache-control',
+                'etag',
+                'location',
+            ],
+            'body_hash_skip_content_types' => [
+                'multipart/form-data',
+                'application/octet-stream',
+            ],
+        ]);
 
         $this->bindRedis();
     }
@@ -485,7 +512,7 @@ class IdempotencyMiddlewareTest extends TestCase
         {
             public function __construct(private string $message) {}
 
-            public function connection(): void
+            public function connection(?string $name = null): void
             {
                 throw new \RuntimeException($this->message);
             }

--- a/tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php
@@ -150,6 +150,26 @@ class IdempotencyMiddlewareTest extends TestCase
         $this->assertSame(['errors' => ['bad']], json_decode($response->getContent(), true));
     }
 
+    public function test_no_content_response_without_content_type_is_cached_and_replayed(): void
+    {
+        $this->handle($this->request(headers: ['Idempotency-Key' => 'no-content-key']), function () {
+            return new \Illuminate\Http\Response('', 204);
+        });
+        $this->app->terminate();
+
+        $called = false;
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'no-content-key']), function () use (&$called) {
+            $called = true;
+
+            return response('rerun', 200, ['Content-Type' => 'text/plain']);
+        });
+
+        $this->assertFalse($called);
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+        $this->assertSame('1', $response->headers->get('X-Idempotency-Replay'));
+    }
+
     public function test_non_replayable_status_codes_delete_inflight_key(): void
     {
         foreach ([401, 403, 404, 500] as $status) {
@@ -302,6 +322,50 @@ class IdempotencyMiddlewareTest extends TestCase
             $called = true;
 
             return response()->json(['order' => 2]);
+        });
+
+        $this->assertTrue($called);
+        $this->assertCount(2, $this->redis->keys());
+    }
+
+    public function test_same_named_route_and_body_with_different_query_does_not_body_hash_replay(): void
+    {
+        $first = $this->request(path: '/orders/1?include=lines', headers: []);
+        $first->setRouteResolver(fn () => new class
+        {
+            public function getName(): string
+            {
+                return 'orders.show';
+            }
+
+            public function parameters(): array
+            {
+                return ['order' => '1'];
+            }
+        });
+
+        $this->handle($first, fn () => response()->json(['include' => 'lines']));
+        $this->app->terminate();
+
+        $second = $this->request(path: '/orders/1?include=charges', headers: []);
+        $second->setRouteResolver(fn () => new class
+        {
+            public function getName(): string
+            {
+                return 'orders.show';
+            }
+
+            public function parameters(): array
+            {
+                return ['order' => '1'];
+            }
+        });
+
+        $called = false;
+        $this->handle($second, function () use (&$called) {
+            $called = true;
+
+            return response()->json(['include' => 'charges']);
         });
 
         $this->assertTrue($called);

--- a/tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php
@@ -1,0 +1,460 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Redis;
+use Mockery;
+use NuiMarkets\LaravelSharedUtils\Auth\JWTUser;
+use NuiMarkets\LaravelSharedUtils\Http\Middleware\IdempotencyMiddleware;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use NuiMarkets\LaravelSharedUtils\Tests\Utils\FakeRedisConnection;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class IdempotencyMiddlewareTest extends TestCase
+{
+    private FakeRedisConnection $redis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::create(2026, 5, 12, 12, 0, 0));
+        config()->set('idempotency', require __DIR__.'/../../../../config/idempotency.php');
+        config()->set('idempotency.enabled', true);
+
+        $this->bindRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_disabled_passes_through_without_redis_call(): void
+    {
+        config()->set('idempotency.enabled', false);
+        $this->bindFailingRedis('Redis should not be called');
+
+        $called = false;
+        $response = $this->handle($this->request(), function () use (&$called) {
+            $called = true;
+
+            return response('ok', 200, ['Content-Type' => 'text/plain']);
+        });
+
+        $this->assertTrue($called);
+        $this->assertSame('ok', $response->getContent());
+    }
+
+    public function test_unauthenticated_passes_through(): void
+    {
+        $request = Request::create('/orders', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '{"x":1}');
+        $called = false;
+
+        $this->handle($request, function () use (&$called) {
+            $called = true;
+
+            return response()->json(['ok' => true]);
+        });
+
+        $this->assertTrue($called);
+        $this->assertSame([], $this->redis->keys());
+    }
+
+    public function test_read_methods_pass_through(): void
+    {
+        foreach (['GET', 'HEAD', 'OPTIONS'] as $method) {
+            $called = false;
+
+            $this->handle($this->request(method: $method), function () use (&$called) {
+                $called = true;
+
+                return response('', 204);
+            });
+
+            $this->assertTrue($called, $method.' should pass through');
+        }
+
+        $this->assertSame([], $this->redis->keys());
+    }
+
+    public function test_malformed_headers_return_400_without_body_hash_fallback(): void
+    {
+        $cases = [
+            '',
+            str_repeat('a', 256),
+            'has space',
+            "has\ncontrol",
+        ];
+
+        foreach ($cases as $header) {
+            $request = $this->request(headers: ['Idempotency-Key' => $header]);
+            $called = false;
+            $response = $this->handle($request, function () use (&$called) {
+                $called = true;
+
+                return response()->json(['ok' => true]);
+            });
+
+            $this->assertFalse($called);
+            $this->assertSame(400, $response->getStatusCode());
+            $this->assertSame('idempotency_key_invalid', json_decode($response->getContent(), true)['error']);
+        }
+
+        $this->assertSame([], $this->redis->keys());
+    }
+
+    public function test_header_request_writes_complete_payload_after_termination(): void
+    {
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'abc-123']), function () {
+            return response()->json(['created' => true], 201, ['Location' => '/orders/1']);
+        });
+
+        $this->assertSame(201, $response->getStatusCode());
+        $key = $this->redis->keys()[0];
+        $this->assertSame('inflight', $this->redis->payload($key)['state']);
+
+        $this->app->terminate();
+
+        $payload = $this->redis->payload($key);
+        $this->assertSame('complete', $payload['state']);
+        $this->assertSame(201, $payload['status']);
+        $this->assertSame('{"created":true}', base64_decode($payload['body_b64']));
+        $this->assertSame('/orders/1', $payload['headers']['location']);
+        $this->assertSame(600, $this->redis->ttlFor($key));
+    }
+
+    public function test_422_response_is_cached_and_replayed(): void
+    {
+        $this->handle($this->request(headers: ['Idempotency-Key' => 'validation-key']), function () {
+            return response()->json(['errors' => ['bad']], 422);
+        });
+        $this->app->terminate();
+
+        $called = false;
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'validation-key']), function () use (&$called) {
+            $called = true;
+
+            return response()->json(['errors' => ['rerun']], 422);
+        });
+
+        $this->assertFalse($called);
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertSame('1', $response->headers->get('X-Idempotency-Replay'));
+        $this->assertSame(['errors' => ['bad']], json_decode($response->getContent(), true));
+    }
+
+    public function test_non_replayable_status_codes_delete_inflight_key(): void
+    {
+        foreach ([401, 403, 404, 500] as $status) {
+            Log::spy();
+            $this->bindRedis();
+
+            $this->handle($this->request(headers: ['Idempotency-Key' => 'status-'.$status]), function () use ($status) {
+                return response()->json(['status' => $status], $status);
+            });
+            $this->app->terminate();
+
+            $this->assertSame([], $this->redis->keys());
+            Log::shouldHaveReceived('info')->with('idempotency.skip_cache', Mockery::on(
+                fn (array $context): bool => ($context['skip_reason'] ?? null) === 'status_code'
+            ));
+        }
+    }
+
+    public function test_complete_payload_replays_allowlisted_headers_only(): void
+    {
+        $this->handle($this->request(headers: ['Idempotency-Key' => 'replay-key']), function () {
+            return response('created', 201, [
+                'Content-Type' => 'text/plain',
+                'Location' => '/orders/1',
+                'Set-Cookie' => 'secret=1',
+                'X-Request-ID' => 'request-1',
+            ]);
+        });
+        $this->app->terminate();
+
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'replay-key']), function () {
+            return response('rerun', 201, ['Content-Type' => 'text/plain']);
+        });
+
+        $this->assertSame('created', $response->getContent());
+        $this->assertSame('/orders/1', $response->headers->get('Location'));
+        $this->assertSame('1', $response->headers->get('X-Idempotency-Replay'));
+        $this->assertSame('201', $response->headers->get('X-Idempotency-Original-Status'));
+        $this->assertFalse($response->headers->has('Set-Cookie'));
+        $this->assertFalse($response->headers->has('X-Request-ID'));
+        $this->assertStringContainsString('no-store', $response->headers->get('Cache-Control'));
+    }
+
+    public function test_same_header_with_different_body_returns_conflict_in_plain_and_jsonapi_shapes(): void
+    {
+        $this->handle($this->request(body: '{"a":1}', headers: ['Idempotency-Key' => 'conflict-key']), function () {
+            return response()->json(['ok' => true]);
+        });
+        $this->app->terminate();
+
+        $plain = $this->handle($this->request(body: '{"a":2}', headers: ['Idempotency-Key' => 'conflict-key']), fn () => response()->json(['rerun' => true]));
+        $jsonApi = $this->handle($this->request(body: '{"a":2}', headers: [
+            'Idempotency-Key' => 'conflict-key',
+            'Accept' => 'application/vnd.api+json',
+        ]), fn () => response()->json(['rerun' => true]));
+
+        $this->assertSame(422, $plain->getStatusCode());
+        $this->assertSame('idempotency_key_conflict', json_decode($plain->getContent(), true)['error']);
+        $this->assertSame('idempotency_key_conflict', json_decode($jsonApi->getContent(), true)['errors'][0]['code']);
+    }
+
+    public function test_inflight_lock_returns_409_with_computed_retry_after(): void
+    {
+        $this->handle($this->request(headers: ['Idempotency-Key' => 'inflight-key']), function () {
+            return response()->json(['slow' => true]);
+        });
+
+        Carbon::setTestNow(now()->addSeconds(15));
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'inflight-key']), fn () => response()->json(['rerun' => true]));
+
+        $this->assertSame(409, $response->getStatusCode());
+        $this->assertSame('45', $response->headers->get('Retry-After'));
+        $this->assertStringContainsString('no-store', $response->headers->get('Cache-Control'));
+    }
+
+    public function test_body_hash_path_uses_30_second_ttl(): void
+    {
+        $this->handle($this->request(headers: []), fn () => response()->json(['ok' => true]));
+        $this->app->terminate();
+
+        $key = $this->redis->keys()[0];
+        $this->assertStringContainsString(':body_hash:', $key);
+        $this->assertSame(30, $this->redis->ttlFor($key));
+    }
+
+    public function test_binary_response_body_replays_byte_identical(): void
+    {
+        $bytes = "abc\xff\x00xyz";
+
+        $this->handle($this->request(headers: ['Idempotency-Key' => 'binary-key']), fn () => response($bytes, 200, ['Content-Type' => 'text/plain']));
+        $this->app->terminate();
+
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'binary-key']), fn () => response('rerun', 200, ['Content-Type' => 'text/plain']));
+
+        $this->assertSame($bytes, $response->getContent());
+    }
+
+    public function test_zero_string_request_body_does_not_hash_as_empty_body(): void
+    {
+        $this->handle($this->request(body: '0', headers: ['Idempotency-Key' => 'zero-body-key']), fn () => response()->json(['ok' => true]));
+        $this->app->terminate();
+
+        $response = $this->handle($this->request(body: '', headers: ['Idempotency-Key' => 'zero-body-key']), fn () => response()->json(['rerun' => true]));
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertSame('idempotency_key_conflict', json_decode($response->getContent(), true)['error']);
+    }
+
+    public function test_zero_string_response_body_replays_byte_identical(): void
+    {
+        $this->handle($this->request(headers: ['Idempotency-Key' => 'zero-response-key']), fn () => response('0', 200, ['Content-Type' => 'text/plain']));
+        $this->app->terminate();
+
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'zero-response-key']), fn () => response('rerun', 200, ['Content-Type' => 'text/plain']));
+
+        $this->assertSame('0', $response->getContent());
+    }
+
+    public function test_cache_keys_include_unit_separators_to_prevent_actor_collisions(): void
+    {
+        $this->handle($this->request(user: new JWTUser('user12', 'org3', 'buyer'), headers: ['Idempotency-Key' => 'key']), fn () => response()->json(['ok' => true]));
+        $this->handle($this->request(user: new JWTUser('user1', 'org23', 'buyer'), headers: ['Idempotency-Key' => 'key']), fn () => response()->json(['ok' => true]));
+
+        $this->assertCount(2, $this->redis->keys());
+    }
+
+    public function test_same_header_and_body_from_different_users_do_not_replay(): void
+    {
+        $this->handle($this->request(user: new JWTUser('user-a', 'org', 'buyer'), headers: ['Idempotency-Key' => 'shared']), fn () => response()->json(['user' => 'a']));
+        $this->app->terminate();
+
+        $called = false;
+        $this->handle($this->request(user: new JWTUser('user-b', 'org', 'buyer'), headers: ['Idempotency-Key' => 'shared']), function () use (&$called) {
+            $called = true;
+
+            return response()->json(['user' => 'b']);
+        });
+
+        $this->assertTrue($called);
+        $this->assertCount(2, $this->redis->keys());
+    }
+
+    public function test_same_body_on_different_route_parameters_does_not_body_hash_replay(): void
+    {
+        $this->handle($this->request(path: '/orders/1', headers: []), fn () => response()->json(['order' => 1]));
+        $this->app->terminate();
+
+        $called = false;
+        $this->handle($this->request(path: '/orders/2', headers: []), function () use (&$called) {
+            $called = true;
+
+            return response()->json(['order' => 2]);
+        });
+
+        $this->assertTrue($called);
+        $this->assertCount(2, $this->redis->keys());
+    }
+
+    public function test_lock_expiry_race_skips_complete_write(): void
+    {
+        Log::spy();
+        config()->set('idempotency.lock_ttl', 1);
+
+        $this->handle($this->request(headers: ['Idempotency-Key' => 'slow-key']), fn () => response()->json(['ok' => true]));
+        Carbon::setTestNow(now()->addSeconds(2));
+        $this->app->terminate();
+
+        $this->assertSame([], $this->redis->keys());
+        Log::shouldHaveReceived('warning')->with('idempotency.lock_expired_before_complete', Mockery::type('array'));
+    }
+
+    public function test_malformed_existing_payload_fails_open(): void
+    {
+        $request = $this->request(headers: ['Idempotency-Key' => 'manual']);
+        $this->handle($request, fn () => response()->json(['seed' => true]));
+
+        $key = $this->redis->keys()[0];
+        $this->redis->set($key, 'not-json', 'EX', 60);
+
+        $called = false;
+        $response = $this->handle($request, function () use (&$called) {
+            $called = true;
+
+            return response()->json(['fresh' => true]);
+        });
+
+        $this->assertTrue($called);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_multipart_without_header_passes_through_but_with_header_caches(): void
+    {
+        $this->handle($this->request(headers: ['Content-Type' => 'multipart/form-data; boundary=x']), fn () => response()->json(['pass' => true]));
+        $this->assertSame([], $this->redis->keys());
+
+        $this->handle($this->request(headers: [
+            'Content-Type' => 'multipart/form-data; boundary=x',
+            'Idempotency-Key' => 'multipart-key',
+        ]), fn () => response()->json(['cache' => true]));
+        $this->app->terminate();
+
+        $this->assertCount(1, $this->redis->keys());
+    }
+
+    public function test_oversize_content_type_and_streamed_responses_are_not_cached(): void
+    {
+        $cases = [
+            'oversize' => function () {
+                config()->set('idempotency.max_response_bytes', 3);
+
+                return response('large', 200, ['Content-Type' => 'text/plain']);
+            },
+            'content_type' => fn () => response('<html></html>', 200, ['Content-Type' => 'text/html']),
+            'streamed' => fn () => new StreamedResponse(fn () => print 'stream', 200, ['Content-Type' => 'text/plain']),
+        ];
+
+        foreach ($cases as $reason => $factory) {
+            Log::spy();
+            config()->set('idempotency.max_response_bytes', 262144);
+            $this->bindRedis();
+
+            $this->handle($this->request(headers: ['Idempotency-Key' => 'skip-'.$reason]), $factory);
+            $this->app->terminate();
+
+            $this->assertSame([], $this->redis->keys());
+            Log::shouldHaveReceived('info')->with('idempotency.skip_cache', Mockery::on(
+                fn (array $context): bool => ($context['skip_reason'] ?? null) === $reason
+            ));
+        }
+    }
+
+    public function test_redis_exception_fails_open(): void
+    {
+        Log::spy();
+        $this->bindFailingRedis('redis down');
+
+        $called = false;
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'redis-down']), function () use (&$called) {
+            $called = true;
+
+            return response()->json(['fresh' => true]);
+        });
+
+        $this->assertTrue($called);
+        $this->assertSame(200, $response->getStatusCode());
+        Log::shouldHaveReceived('warning')->with('idempotency.fail_open', Mockery::type('array'));
+    }
+
+    private function bindRedis(?FakeRedisConnection $redis = null): FakeRedisConnection
+    {
+        $this->redis = $redis ?? new FakeRedisConnection;
+
+        Redis::swap(new class($this->redis)
+        {
+            public function __construct(private FakeRedisConnection $connection) {}
+
+            public function connection(string $name = 'default'): FakeRedisConnection
+            {
+                return $this->connection;
+            }
+        });
+
+        return $this->redis;
+    }
+
+    private function bindFailingRedis(string $message): void
+    {
+        Redis::swap(new class($message)
+        {
+            public function __construct(private string $message) {}
+
+            public function connection(): void
+            {
+                throw new \RuntimeException($this->message);
+            }
+        });
+    }
+
+    private function handle(Request $request, callable $next): \Symfony\Component\HttpFoundation\Response
+    {
+        return (new IdempotencyMiddleware)->handle($request, $next);
+    }
+
+    private function request(
+        string $method = 'POST',
+        string $path = '/orders/1',
+        string $body = '{"product":"beef"}',
+        array $headers = ['Idempotency-Key' => 'test-key'],
+        ?JWTUser $user = null,
+    ): Request {
+        $server = ['CONTENT_TYPE' => 'application/json'];
+
+        foreach ($headers as $name => $value) {
+            if (strtolower($name) === 'content-type') {
+                $server['CONTENT_TYPE'] = $value;
+            } elseif (strtolower($name) === 'accept') {
+                $server['HTTP_ACCEPT'] = $value;
+            } else {
+                $server['HTTP_'.strtoupper(str_replace('-', '_', $name))] = $value;
+            }
+        }
+
+        $request = Request::create($path, $method, [], [], [], $server, $body);
+        $request->setUserResolver(fn () => $user ?? new JWTUser('user-1', 'org-1', 'buyer'));
+
+        return $request;
+    }
+}

--- a/tests/Utils/FakeRedisConnection.php
+++ b/tests/Utils/FakeRedisConnection.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Utils;
+
+class FakeRedisConnection
+{
+    public array $sets = [];
+
+    public array $deleted = [];
+
+    private array $store = [];
+
+    private array $expiresAt = [];
+
+    public function set(string $key, string $value, ...$options): bool
+    {
+        $this->purgeExpired($key);
+
+        if (in_array('NX', $options, true) && array_key_exists($key, $this->store)) {
+            return false;
+        }
+
+        $ttl = $this->extractTtl($options);
+        $this->store[$key] = $value;
+        $this->expiresAt[$key] = $ttl === null ? null : now()->getTimestamp() + $ttl;
+        $this->sets[] = [
+            'key' => $key,
+            'value' => $value,
+            'options' => $options,
+            'ttl' => $ttl,
+        ];
+
+        return true;
+    }
+
+    public function get(string $key): ?string
+    {
+        $this->purgeExpired($key);
+
+        return $this->store[$key] ?? null;
+    }
+
+    public function del(string $key): int
+    {
+        $this->purgeExpired($key);
+        $deleted = array_key_exists($key, $this->store) ? 1 : 0;
+
+        unset($this->store[$key], $this->expiresAt[$key]);
+        $this->deleted[] = $key;
+
+        return $deleted;
+    }
+
+    public function keys(): array
+    {
+        foreach (array_keys($this->store) as $key) {
+            $this->purgeExpired($key);
+        }
+
+        return array_keys($this->store);
+    }
+
+    public function payload(string $key): ?array
+    {
+        $value = $this->get($key);
+
+        return $value === null ? null : json_decode($value, true);
+    }
+
+    public function ttlFor(string $key): ?int
+    {
+        foreach (array_reverse($this->sets) as $set) {
+            if ($set['key'] === $key) {
+                return $set['ttl'];
+            }
+        }
+
+        return null;
+    }
+
+    private function extractTtl(array $options): ?int
+    {
+        foreach ($options as $index => $option) {
+            if ($option === 'EX' && isset($options[$index + 1])) {
+                return (int) $options[$index + 1];
+            }
+        }
+
+        return null;
+    }
+
+    private function purgeExpired(string $key): void
+    {
+        if (($this->expiresAt[$key] ?? null) !== null && $this->expiresAt[$key] <= now()->getTimestamp()) {
+            unset($this->store[$key], $this->expiresAt[$key]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an opt-in IdempotencyMiddleware for write requests using Idempotency-Key with a body-hash fallback.
- Cache replayable responses in Redis with fingerprint checks, inflight rejection, and fail-open handling.
- Add idempotency config, service provider publishing, unit coverage, feature coverage, and a reusable fake Redis connection.

## Test plan
- [x] composer test IdempotencyMiddleware
- [x] composer test-all
- [x] git diff --check master...HEAD
- [ ] vendor/bin/pint --test (currently fails on unrelated pre-existing formatting issues in JsonApiCollection, HeaderResolverInterface, RemoteRepositoryHeaderForwardingTest, and JsonApiCollectionTest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in idempotency for write requests: Idempotency-Key support, body-hash fallback, inflight locking, replayable responses, conflict handling, and Retry-After behavior.
  * Configurable idempotency options: enablement, storage, TTLs, header rules, content-type and size limits.

* **Chores**
  * Service provider to merge and publish idempotency configuration.

* **Tests**
  * Extensive unit and feature tests plus an in-memory Redis test utility covering lifecycle, edge cases, errors, and logging.

* **Documentation**
  * Added user-facing idempotency docs and README section.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuimarkets/nui-laravel-shared-utils/pull/97)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->