### PR TITLE
feat(idempotency): add metric-ready telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ php artisan vendor:publish --provider="NuiMarkets\LaravelSharedUtils\Providers\L
 # Publish specific configs
 php artisan vendor:publish --tag=logging-utils-config
 php artisan vendor:publish --tag=intercom-config
+php artisan vendor:publish --tag=idempotency-config
 ```
 
 ## Documentation

--- a/config/idempotency.php
+++ b/config/idempotency.php
@@ -28,4 +28,10 @@ return [
         'multipart/form-data',
         'application/octet-stream',
     ],
+    'metrics_namespace' => env('IDEMPOTENCY_METRICS_NAMESPACE', 'LaravelSharedUtils/Idempotency'),
+    'metric_names' => [
+        'cache_hit' => env('IDEMPOTENCY_CACHE_HIT_METRIC_NAME', 'IdempotencyCacheHits'),
+        'conflict' => env('IDEMPOTENCY_CONFLICT_METRIC_NAME', 'IdempotencyConflicts'),
+        'fail_open' => env('IDEMPOTENCY_FAIL_OPEN_METRIC_NAME', 'IdempotencyFailOpenEvents'),
+    ],
 ];

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -269,10 +269,28 @@ return [
         'multipart/form-data',
         'application/octet-stream',
     ],
+    'metrics_namespace' => env(
+        'IDEMPOTENCY_METRICS_NAMESPACE',
+        'LaravelSharedUtils/Idempotency'
+    ),
+    'metric_names' => [
+        'cache_hit' => env(
+            'IDEMPOTENCY_CACHE_HIT_METRIC_NAME',
+            'IdempotencyCacheHits'
+        ),
+        'conflict' => env(
+            'IDEMPOTENCY_CONFLICT_METRIC_NAME',
+            'IdempotencyConflicts'
+        ),
+        'fail_open' => env(
+            'IDEMPOTENCY_FAIL_OPEN_METRIC_NAME',
+            'IdempotencyFailOpenEvents'
+        ),
+    ],
 ];
 ```
 
-## Logging
+## Logging And Metrics
 
 The middleware logs these events:
 
@@ -293,6 +311,27 @@ Skip cache logs include `skip_reason`:
 
 Redis errors fail open. The request continues through the application and the
 middleware logs `idempotency.fail_open`.
+
+Replay, conflict, and fail-open logs also carry metric-ready fields:
+
+- `idempotency_metric_namespace`
+- `idempotency_metric_name`
+- `idempotency_metric_value`
+- `idempotency_metric_unit`
+
+Defaults:
+
+| Event | Metric key | Default metric name |
+| ------- | ------------ | --------------------- |
+| `idempotency.replay` | `cache_hit` | `IdempotencyCacheHits` |
+| `idempotency.conflict` | `conflict` | `IdempotencyConflicts` |
+| `idempotency.fail_open` | `fail_open` | `IdempotencyFailOpenEvents` |
+
+Set `IDEMPOTENCY_METRICS_NAMESPACE` in a consuming service to place these
+signals in the service's CloudWatch namespace. These fields are intentionally
+low-cardinality so CloudWatch Logs metric filters, Elasticsearch alerts, or
+log queries can count events per minute without using `cache_key` or
+`fingerprint` as dimensions.
 
 ## Testing
 

--- a/src/Http/Middleware/IdempotencyMiddleware.php
+++ b/src/Http/Middleware/IdempotencyMiddleware.php
@@ -17,6 +17,12 @@ class IdempotencyMiddleware
 {
     private const SEPARATOR = "\x1f";
 
+    private const METRIC_EVENTS = [
+        'idempotency.replay' => 'cache_hit',
+        'idempotency.conflict' => 'conflict',
+        'idempotency.fail_open' => 'fail_open',
+    ];
+
     public function handle(Request $request, Closure $next): Response
     {
         if (! config('idempotency.enabled', false)) {
@@ -498,6 +504,27 @@ class IdempotencyMiddleware
             'cache_key' => $cacheKey,
             'fingerprint' => $fingerprint,
             'request_id' => request()?->headers->get('X-Request-ID'),
-        ], $context));
+        ], $this->metricContext($event), $context));
+    }
+
+    private function metricContext(string $event): array
+    {
+        $metricKey = self::METRIC_EVENTS[$event] ?? null;
+
+        if ($metricKey === null) {
+            return [];
+        }
+
+        $metricName = config('idempotency.metric_names.'.$metricKey);
+        if (! is_string($metricName) || $metricName === '') {
+            return [];
+        }
+
+        return [
+            'idempotency_metric_namespace' => (string) config('idempotency.metrics_namespace', 'LaravelSharedUtils/Idempotency'),
+            'idempotency_metric_name' => $metricName,
+            'idempotency_metric_value' => 1,
+            'idempotency_metric_unit' => 'Count',
+        ];
     }
 }

--- a/tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php
@@ -50,6 +50,12 @@ class IdempotencyMiddlewareTest extends TestCase
                 'multipart/form-data',
                 'application/octet-stream',
             ],
+            'metrics_namespace' => 'Test/Idempotency',
+            'metric_names' => [
+                'cache_hit' => 'IdempotencyCacheHits',
+                'conflict' => 'IdempotencyConflicts',
+                'fail_open' => 'IdempotencyFailOpenEvents',
+            ],
         ]);
 
         $this->bindRedis();
@@ -240,12 +246,36 @@ class IdempotencyMiddlewareTest extends TestCase
         $this->assertStringContainsString('no-store', $response->headers->get('Cache-Control'));
     }
 
+    public function test_replay_logs_cache_hit_metric_context(): void
+    {
+        $this->handle($this->request(headers: ['Idempotency-Key' => 'metric-replay-key']), function () {
+            return response()->json(['created' => true]);
+        });
+        $this->app->terminate();
+
+        Log::spy();
+
+        $response = $this->handle($this->request(headers: ['Idempotency-Key' => 'metric-replay-key']), function () {
+            return response()->json(['rerun' => true]);
+        });
+
+        $this->assertSame('1', $response->headers->get('X-Idempotency-Replay'));
+        Log::shouldHaveReceived('info')->with('idempotency.replay', Mockery::on(
+            fn (array $context): bool => ($context['idempotency_metric_namespace'] ?? null) === 'Test/Idempotency'
+                && ($context['idempotency_metric_name'] ?? null) === 'IdempotencyCacheHits'
+                && ($context['idempotency_metric_value'] ?? null) === 1
+                && ($context['idempotency_metric_unit'] ?? null) === 'Count'
+        ));
+    }
+
     public function test_same_header_with_different_body_returns_conflict_in_plain_and_jsonapi_shapes(): void
     {
         $this->handle($this->request(body: '{"a":1}', headers: ['Idempotency-Key' => 'conflict-key']), function () {
             return response()->json(['ok' => true]);
         });
         $this->app->terminate();
+
+        Log::spy();
 
         $plain = $this->handle($this->request(body: '{"a":2}', headers: ['Idempotency-Key' => 'conflict-key']), fn () => response()->json(['rerun' => true]));
         $jsonApi = $this->handle($this->request(body: '{"a":2}', headers: [
@@ -256,6 +286,12 @@ class IdempotencyMiddlewareTest extends TestCase
         $this->assertSame(422, $plain->getStatusCode());
         $this->assertSame('idempotency_key_conflict', json_decode($plain->getContent(), true)['error']);
         $this->assertSame('idempotency_key_conflict', json_decode($jsonApi->getContent(), true)['errors'][0]['code']);
+        Log::shouldHaveReceived('info')->with('idempotency.conflict', Mockery::on(
+            fn (array $context): bool => ($context['idempotency_metric_namespace'] ?? null) === 'Test/Idempotency'
+                && ($context['idempotency_metric_name'] ?? null) === 'IdempotencyConflicts'
+                && ($context['idempotency_metric_value'] ?? null) === 1
+                && ($context['idempotency_metric_unit'] ?? null) === 'Count'
+        ));
     }
 
     public function test_inflight_lock_returns_409_with_computed_retry_after(): void
@@ -486,7 +522,12 @@ class IdempotencyMiddlewareTest extends TestCase
 
         $this->assertTrue($called);
         $this->assertSame(200, $response->getStatusCode());
-        Log::shouldHaveReceived('warning')->with('idempotency.fail_open', Mockery::type('array'));
+        Log::shouldHaveReceived('warning')->with('idempotency.fail_open', Mockery::on(
+            fn (array $context): bool => ($context['idempotency_metric_namespace'] ?? null) === 'Test/Idempotency'
+                && ($context['idempotency_metric_name'] ?? null) === 'IdempotencyFailOpenEvents'
+                && ($context['idempotency_metric_value'] ?? null) === 1
+                && ($context['idempotency_metric_unit'] ?? null) === 'Count'
+        ));
     }
 
     private function bindRedis(?FakeRedisConnection $redis = null): FakeRedisConnection


### PR DESCRIPTION
## Summary
- Add configurable metric namespace and metric names for idempotency replay, conflict, and fail-open events.
- Attach low-cardinality metric fields to replay, conflict, and fail-open logs for CloudWatch or ES alerting.
- Document the metric contract and config publishing path for package consumers.
- Cover replay, conflict, and fail-open metric context in middleware tests.

## Review
- Local review/checks completed.
- External Gemini review was not run: sandbox escalation was rejected because it would disclose private repo diff content to an external service.
- Markdownlint has pre-existing repo-wide findings; the new table separator finding in `docs/idempotency.md` was fixed.

## Changes
- Add idempotency metric config defaults.
- Add metric context to replay, conflict, and fail-open logs.
- Update idempotency docs and README publishing command.
- Extend middleware telemetry assertions.

## Test plan
- [x] `composer test IdempotencyMiddleware`
- [x] `vendor/bin/pint config/idempotency.php src/Http/Middleware/IdempotencyMiddleware.php tests/Unit/Http/Middleware/IdempotencyMiddlewareTest.php`
- [x] `git diff --check origin/master...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added metrics configuration support for idempotency tracking, including customizable namespace and metric names for cache hits, conflicts, and fail-open events
  * Enhanced logging with metric context fields for improved observability

* **Documentation**
  * Updated configuration and logging documentation with metrics-related settings and examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuimarkets/nui-laravel-shared-utils/pull/99)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->