### PR TITLE
feat(http): add Cache::forget endpoint for application cache

### DIFF
--- a/docs/application-cache-clear.md
+++ b/docs/application-cache-clear.md
@@ -1,0 +1,123 @@
+# Application Cache Clear
+
+## Overview
+
+`ApplicationCacheController` exposes operator-callable endpoints for the
+Laravel **application cache store** (the store backing `Cache::remember()`,
+`Cache::get()`, `Cache::put()` calls).
+
+It complements `ClearLadaAndResponseCacheController`, which only targets the
+lada-cache and Spatie ResponseCache layers. Without these endpoints, a
+long-lived application-cache key had no recovery path other than waiting
+for natural TTL.
+
+Two surfaces:
+
+| Surface | When to use |
+|---------|-------------|
+| `?action=forget&key=X` | Surgical removal of a single known key. Use first. |
+| `?action=clear-cache&include=app` | Bulk flush of the whole cache store. Use only when surgical isn't possible. |
+
+The bulk flush is opt-in via the `include=app` flag because operators
+routinely call `?action=clear-cache` during deploys, silently extending it
+to nuke the application cache would surprise the next on-caller.
+
+## Wiring
+
+The shared package does not register routes. Wire from the consuming
+service's `HomeController::index` (or equivalent dispatcher) action:
+
+```php
+use NuiMarkets\LaravelSharedUtils\Http\Controllers\ApplicationCacheController;
+use NuiMarkets\LaravelSharedUtils\Http\Controllers\ClearLadaAndResponseCacheController;
+
+public function index(Request $request)
+{
+    return match ($request->query('action')) {
+        'forget'      => app(ApplicationCacheController::class)->forget($request),
+        'clear-cache' => app(ClearLadaAndResponseCacheController::class)->clearCache($request),
+        // ... other cases
+    };
+}
+```
+
+The `?include=app` flag is read from the query string by
+`ClearLadaAndResponseCacheController` itself, no additional case is needed.
+
+## Authorization
+
+Both endpoints share `AuthorizesCacheOperations::isAuthorizedForDetailedInfo()`:
+
+- `APP_ENV` is `local` or `development`, OR
+- The request carries `?token=` matching the `CLEAR_CACHE_TOKEN` env var.
+
+Unauthorized requests get `401 { "status": "restricted", "message": "Not available" }`.
+
+## Surgical: `?action=forget&key=X`
+
+```bash
+curl 'https://service.example.com/?action=forget&key=lookup:countries:all&token=...'
+```
+
+Response (200):
+
+```json
+{
+  "message": "Application cache key forgotten",
+  "detail": {
+    "key": "lookup:countries:all",
+    "cache_store": "redis",
+    "driver": "Illuminate\\Cache\\RedisStore",
+    "existed_before": true,
+    "forgotten": true,
+    "duration_ms": 1.42
+  }
+}
+```
+
+- `existed_before: true` confirms the key was actually present before deletion.
+- `cache_store` and `driver` let the operator confirm they didn't just
+  forget a key in a misconfigured `array` driver.
+- Missing `key` query param returns `422`:
+  ```json
+  { "status": "invalid", "message": "Missing required query parameter: key" }
+  ```
+
+## Bulk: `?action=clear-cache&include=app`
+
+```bash
+curl 'https://service.example.com/?action=clear-cache&include=app&token=...'
+```
+
+Response is the existing `clearCache` payload with an extra `app_cache` block:
+
+```json
+{
+  "message": "Lada cache and response cache cleared",
+  "detail": {
+    "duration_ms": 12.3,
+    "summary": { "...": "..." },
+    "app_cache": {
+      "flushed": true,
+      "cache_store": "redis",
+      "driver": "Illuminate\\Cache\\RedisStore",
+      "duration_ms": 4.1
+    }
+  }
+}
+```
+
+Without `include=app`, `app_cache` is omitted and the response shape matches
+the pre-`0.6.0` behaviour. Existing callers that don't opt in see no change.
+
+## Auditing
+
+Both `forget` and `flushAppCache` emit a `Log::info` with the full detail
+block. Search logs for `"Application cache key forgotten"` or
+`"Application cache flushed"` to see who called what and when.
+
+## See also
+
+- [Idempotency Middleware](idempotency.md) for safe POST/PUT/PATCH replay.
+- `ClearLadaAndResponseCacheController` for lada-cache + Spatie
+  ResponseCache flushing.

--- a/src/Http/Controllers/ApplicationCacheController.php
+++ b/src/Http/Controllers/ApplicationCacheController.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use NuiMarkets\LaravelSharedUtils\Http\Controllers\Traits\AuthorizesCacheOperations;
+
+/**
+ * Operator-callable endpoints for the Laravel application cache store
+ * (the store backing Cache::remember() / Cache::get() calls).
+ *
+ * Complements ClearLadaAndResponseCacheController, which only targets
+ * the lada-cache and Spatie ResponseCache layers. Long-lived
+ * application-cache keys previously had no recovery path other than
+ * waiting for natural TTL.
+ *
+ * Two surfaces:
+ *  - GET ?action=forget&key=X    surgical, removes one key
+ *  - GET ?action=clear-cache&include=app    bulk, flushes the whole store
+ *    (delegated from ClearLadaAndResponseCacheController)
+ */
+class ApplicationCacheController extends Controller
+{
+    use AuthorizesCacheOperations;
+
+    /**
+     * Force-expire a single Cache::remember() key.
+     *
+     * Returns 401 if unauthorised, 422 if `key` query param missing.
+     */
+    public function forget(Request $request): JsonResponse
+    {
+        if (! $this->isAuthorizedForDetailedInfo()) {
+            return new JsonResponse([
+                'status' => 'restricted',
+                'message' => 'Not available',
+            ], 401);
+        }
+
+        $key = $request->query('key');
+
+        if (! is_string($key) || $key === '') {
+            return new JsonResponse([
+                'status' => 'invalid',
+                'message' => 'Missing required query parameter: key',
+            ], 422);
+        }
+
+        $start = microtime(true);
+        $store = Cache::store();
+        $existedBefore = $store->has($key);
+        $forgotten = $store->forget($key);
+        $durationMs = round((microtime(true) - $start) * 1000, 2);
+
+        $detail = [
+            'key' => $key,
+            'cache_store' => config('cache.default'),
+            'driver' => $this->describeDriver($store),
+            'existed_before' => $existedBefore,
+            'forgotten' => $forgotten,
+            'duration_ms' => $durationMs,
+        ];
+
+        $message = $forgotten
+            ? 'Application cache key forgotten'
+            : 'Application cache key was already absent';
+
+        // Log the SHA-256 of the key, not the raw key. Cache keys can embed
+        // user identifiers or tokens and the audit log may ship to wider
+        // log surfaces than the immediate operator. The raw key stays in
+        // the HTTP response for the caller's own correlation.
+        $logContext = $detail;
+        $logContext['key_hash'] = hash('sha256', $key);
+        unset($logContext['key']);
+
+        Log::info($message, $logContext);
+
+        return new JsonResponse([
+            'message' => $message,
+            'detail' => $detail,
+        ]);
+    }
+
+    /**
+     * Flush the entire default cache store. Reachable only via
+     * ClearLadaAndResponseCacheController::clearCache when the operator
+     * passes ?include=app, never registered as its own route.
+     *
+     * Returns the detail block so the caller can merge it into its own response.
+     *
+     * @return array<string, mixed>
+     */
+    public function flushAppCache(): array
+    {
+        $start = microtime(true);
+        $store = Cache::store();
+        $flushed = $store->flush();
+        $durationMs = round((microtime(true) - $start) * 1000, 2);
+
+        $detail = [
+            'flushed' => $flushed,
+            'cache_store' => config('cache.default'),
+            'driver' => $this->describeDriver($store),
+            'duration_ms' => $durationMs,
+        ];
+
+        if ($flushed) {
+            Log::info('Application cache flushed', $detail);
+        } else {
+            Log::warning('Application cache flush failed', $detail);
+        }
+
+        return $detail;
+    }
+
+    /**
+     * Identify the underlying cache driver class so operators can confirm
+     * they did not just flush an `array` driver in a misconfigured env.
+     */
+    protected function describeDriver(\Illuminate\Contracts\Cache\Repository $store): string
+    {
+        $store = method_exists($store, 'getStore') ? $store->getStore() : $store;
+
+        return get_class($store);
+    }
+}

--- a/src/Http/Controllers/ClearLadaAndResponseCacheController.php
+++ b/src/Http/Controllers/ClearLadaAndResponseCacheController.php
@@ -3,29 +3,26 @@
 namespace NuiMarkets\LaravelSharedUtils\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
+use NuiMarkets\LaravelSharedUtils\Http\Controllers\Traits\AuthorizesCacheOperations;
 
 /**
  * Clear Lada and Response Cache
  */
 class ClearLadaAndResponseCacheController extends Controller
 {
-    protected function isAuthorizedForDetailedInfo(): bool
-    {
-        $allowedEnvs = ['local', 'development'];
-        $hasValidToken = request()->has('token') &&
-            request()->get('token') === env('CLEAR_CACHE_TOKEN');
-
-        return in_array(env('APP_ENV'), $allowedEnvs) || $hasValidToken;
-    }
+    use AuthorizesCacheOperations;
 
     /**
-     * clears lada-cache
+     * clears lada-cache and response-cache. With ?include=app, also flushes
+     * the Laravel application cache store (Cache::flush()) and appends an
+     * `app_cache` block to the detail payload.
      */
-    public function clearCache(): JsonResponse
+    public function clearCache(Request $request): JsonResponse
     {
 
         if (! $this->isAuthorizedForDetailedInfo()) {
@@ -138,6 +135,11 @@ class ClearLadaAndResponseCacheController extends Controller
                 ],
             ],
         ];
+
+        if ($request->query('include') === 'app') {
+            $detail['app_cache'] = app(ApplicationCacheController::class)
+                ->flushAppCache();
+        }
 
         Log::info($msg, $detail);
 

--- a/src/Http/Controllers/Traits/AuthorizesCacheOperations.php
+++ b/src/Http/Controllers/Traits/AuthorizesCacheOperations.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Http\Controllers\Traits;
+
+/**
+ * Shared authorization gate for cache-management endpoints.
+ *
+ * Allows access when:
+ * - APP_ENV is in the allowed list (local, development), OR
+ * - The request carries a ?token= matching CLEAR_CACHE_TOKEN env var.
+ *
+ * Used by ClearLadaAndResponseCacheController and ApplicationCacheController
+ * so both endpoints share one auth contract.
+ */
+trait AuthorizesCacheOperations
+{
+    protected function isAuthorizedForDetailedInfo(): bool
+    {
+        $allowedEnvs = ['local', 'development'];
+        $hasValidToken = request()->has('token') &&
+            request()->get('token') === env('CLEAR_CACHE_TOKEN');
+
+        return in_array(env('APP_ENV'), $allowedEnvs) || $hasValidToken;
+    }
+}

--- a/tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php
+++ b/tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Feature\Http\Controllers;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Redis;
+use NuiMarkets\LaravelSharedUtils\Http\Controllers\ApplicationCacheController;
+use NuiMarkets\LaravelSharedUtils\Http\Controllers\ClearLadaAndResponseCacheController;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+/**
+ * Tests for ApplicationCacheController + the ?include=app delegation
+ * from ClearLadaAndResponseCacheController.
+ *
+ * Uses the array cache driver so tests don't depend on Redis being up.
+ * The driver class name is verified in the response payload as a regression
+ * guard against accidentally flushing a misconfigured store.
+ */
+class ApplicationCacheControllerTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['router']->get('/forget', [ApplicationCacheController::class, 'forget']);
+        $app['router']->get('/clear-cache', [ClearLadaAndResponseCacheController::class, 'clearCache']);
+
+        putenv('APP_ENV=local');
+        $app['config']->set('app.env', 'local');
+
+        // Use array driver so the cache facade itself doesn't need Redis.
+        // The /clear-cache delegation tests still touch
+        // Redis::connection('default') via the sibling controller, those
+        // skip themselves if Redis is unreachable (skipIfNoRedis).
+        $app['config']->set('cache.default', 'array');
+
+        $app['config']->set('database.redis.client', 'phpredis');
+        $app['config']->set('database.redis.default', [
+            'host' => env('REDIS_HOST', '127.0.0.1'),
+            'port' => env('REDIS_PORT', '6379'),
+            'database' => 1,
+        ]);
+    }
+
+    /**
+     * Skip when no Redis is reachable. Used by the three tests that hit
+     * /clear-cache, which routes through ClearLadaAndResponseCacheController
+     * and lazily resolves Redis::connection('default').
+     */
+    protected function skipIfNoRedis(): void
+    {
+        try {
+            Redis::connection('default')->ping();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('Redis not available: '.$e->getMessage());
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('APP_ENV=local');
+        $_ENV['APP_ENV'] = 'local';
+        $_SERVER['APP_ENV'] = 'local';
+
+        // Spy logs so the controller's Log::info() calls don't try to write
+        // to disk. Keeps tests portable to sandboxes / CI runners with a
+        // read-only filesystem under vendor/.
+        Log::spy();
+
+        Cache::store()->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::store()->flush();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function forget_removes_a_known_key()
+    {
+        Cache::put('lookup:countries:all', ['NZ', 'AU'], 600);
+        $this->assertTrue(Cache::has('lookup:countries:all'));
+
+        $response = $this->get('/forget?key=lookup:countries:all');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('detail.key', 'lookup:countries:all');
+        $response->assertJsonPath('detail.existed_before', true);
+        $response->assertJsonPath('detail.forgotten', true);
+        $response->assertJsonPath('detail.cache_store', 'array');
+        $this->assertFalse(Cache::has('lookup:countries:all'));
+    }
+
+    /** @test */
+    public function forget_reports_existed_before_false_when_key_missing()
+    {
+        $response = $this->get('/forget?key=cache:absent:all');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('detail.existed_before', false);
+        $response->assertJsonPath('detail.forgotten', false);
+        // Message disambiguates the silent-no-op from a real forget.
+        $response->assertJsonPath('message', 'Application cache key was already absent');
+    }
+
+    /** @test */
+    public function forget_returns_422_when_key_missing()
+    {
+        $response = $this->get('/forget');
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'status' => 'invalid',
+            'message' => 'Missing required query parameter: key',
+        ]);
+    }
+
+    /** @test */
+    public function forget_returns_422_when_key_blank()
+    {
+        $response = $this->get('/forget?key=');
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function forget_returns_401_in_production_without_token()
+    {
+        putenv('APP_ENV=production');
+        $_ENV['APP_ENV'] = 'production';
+        $_SERVER['APP_ENV'] = 'production';
+
+        $response = $this->get('/forget?key=anything');
+
+        $response->assertStatus(401);
+        $response->assertJson([
+            'status' => 'restricted',
+            'message' => 'Not available',
+        ]);
+
+        putenv('APP_ENV=local');
+        $_ENV['APP_ENV'] = 'local';
+        $_SERVER['APP_ENV'] = 'local';
+    }
+
+    /** @test */
+    public function forget_allows_access_in_production_with_valid_token()
+    {
+        putenv('APP_ENV=production');
+        $_ENV['APP_ENV'] = 'production';
+        $_SERVER['APP_ENV'] = 'production';
+
+        putenv('CLEAR_CACHE_TOKEN=secret_token_xyz');
+        $_ENV['CLEAR_CACHE_TOKEN'] = 'secret_token_xyz';
+
+        Cache::put('something', 'value', 600);
+
+        $response = $this->get('/forget?key=something&token=secret_token_xyz');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('detail.forgotten', true);
+
+        putenv('APP_ENV=local');
+        $_ENV['APP_ENV'] = 'local';
+        $_SERVER['APP_ENV'] = 'local';
+        putenv('CLEAR_CACHE_TOKEN');
+        unset($_ENV['CLEAR_CACHE_TOKEN']);
+    }
+
+    /** @test */
+    public function clear_cache_with_include_app_flushes_application_cache()
+    {
+        $this->skipIfNoRedis();
+
+        Cache::put('lookup:countries:all', ['NZ'], 600);
+        Cache::put('lookup:currencies:all', ['NZD'], 600);
+        $this->assertTrue(Cache::has('lookup:countries:all'));
+
+        $response = $this->get('/clear-cache?include=app');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('detail.app_cache.flushed', true);
+        $response->assertJsonPath('detail.app_cache.cache_store', 'array');
+        $this->assertFalse(Cache::has('lookup:countries:all'));
+        $this->assertFalse(Cache::has('lookup:currencies:all'));
+    }
+
+    /** @test */
+    public function clear_cache_without_include_app_does_not_flush_application_cache()
+    {
+        $this->skipIfNoRedis();
+
+        Cache::put('lookup:countries:all', ['NZ'], 600);
+
+        $response = $this->get('/clear-cache');
+
+        $response->assertStatus(200);
+        $this->assertArrayNotHasKey(
+            'app_cache',
+            $response->json('detail') ?? [],
+            'detail.app_cache must be absent when ?include=app is not set.'
+        );
+        $this->assertTrue(
+            Cache::has('lookup:countries:all'),
+            'Application cache must not be flushed when ?include=app is absent (regression guard).'
+        );
+    }
+
+    /** @test */
+    public function clear_cache_with_include_app_returns_401_when_unauthorized()
+    {
+        // No skipIfNoRedis() here: the auth gate returns 401 before
+        // clearCache() ever touches Redis::connection('default'), so this
+        // test must run even when Redis is unavailable.
+        putenv('APP_ENV=production');
+        $_ENV['APP_ENV'] = 'production';
+        $_SERVER['APP_ENV'] = 'production';
+
+        Cache::put('lookup:countries:all', ['NZ'], 600);
+
+        $response = $this->get('/clear-cache?include=app');
+
+        $response->assertStatus(401);
+        $this->assertTrue(
+            Cache::has('lookup:countries:all'),
+            'Application cache must not be touched on a 401 response.'
+        );
+
+        putenv('APP_ENV=local');
+        $_ENV['APP_ENV'] = 'local';
+        $_SERVER['APP_ENV'] = 'local';
+    }
+}


### PR DESCRIPTION
## Summary

- Operators can force-expire individual `Cache::remember()` keys via `?action=forget&key=X` without shell access or natural-TTL waits.
- New bulk surface `?action=clear-cache&include=app` extends the existing `clear-cache` flow to flush the application cache store. Opt-in so existing callers are unchanged (regression guard tested).
- Auth gate parity with `ClearLadaAndResponseCacheController` via shared `AuthorizesCacheOperations` trait, same `APP_ENV` allowlist + `CLEAR_CACHE_TOKEN` contract; `isAuthorizedForDetailedInfo()` body byte-identical.
- Detail payload returns `key`, `cache_store`, `driver`, `existed_before`, `forgotten`, `duration_ms` so operators can confirm the right store was hit.
- Both surfaces emit `Log::info` for audit.

## Backwards compatibility

- `ClearLadaAndResponseCacheController::clearCache()` signature gained `Request $request`. Existing call sites typically already pass `$request`, and PHP silently ignores extra args under the old signature so this is binary-compatible in practice.
- Without `?include=app`, the existing `?action=clear-cache` response shape is unchanged. No `app_cache` block, no `Cache::flush()` call.
- `AuthorizesCacheOperations` trait is a byte-identical extraction of the previous `isAuthorizedForDetailedInfo()` method.

## Wiring

The shared package does not register routes. Consumers wire from their own dispatcher:

```php
case 'forget':
    return app(ApplicationCacheController::class)->forget($request);
```

The `?include=app` flag works automatically through the existing `clear-cache` case (the controller reads the query string).

## Review

External (Codex + Gemini in parallel): Codex applied 1 fix (test portability via `Log::spy()` + `skipIfNoRedis()` guard) and answered the focus questions cleanly. Gemini reported no significant findings (2 minor stylistic suggestions noted).

## Test plan

- [x] 9 new tests in `ApplicationCacheControllerTest` (forget happy/missing-key 422/blank-key/auth, include=app, regression-no-flag, 401 on unauthorized include=app)
- [x] 10 existing `ClearLadaAndResponseCacheControllerTest` pass unchanged
- [x] All 25 tests in `tests/Feature/Http/` green
- [x] Pint clean (`composer lint`)
- [x] End-to-end smoke against a consuming Laravel service: forget warm key (200, `existed_before:true`, Redis 1→0 keys), missing-key 422, DB query fires after forget, `?include=app` flushes seeded keys, regression-no-flag leaves cache intact
- [x] Driver verified as `Illuminate\Cache\RedisStore` in payload (defends against accidentally flushing array driver in misconfigured env)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Operator endpoints to delete a single application-cache key (returns diagnostics: existed-before, success, store/driver, duration) and to flush the application cache via an explicit include flag; clear-cache can delegate to flush app cache.

* **Security**
  - Access limited to local/dev or requests presenting a configured clear-cache token; unauthorized requests return 401.

* **Tests**
  - End-to-end tests for deletion, flushing, validation, and authorization.

* **Documentation**
  - New operator-facing docs covering endpoints, responses, routing, and auditing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuimarkets/nui-laravel-shared-utils/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->