### PR TITLE
fix(http): make cache auth token-only, drop env allowlist

### DIFF
--- a/docs/application-cache-clear.md
+++ b/docs/application-cache-clear.md
@@ -46,12 +46,27 @@ The `?include=app` flag is read from the query string by
 
 ## Authorization
 
-Both endpoints share `AuthorizesCacheOperations::isAuthorizedForDetailedInfo()`:
+Both endpoints share `AuthorizesCacheOperations::isAuthorizedForDetailedInfo()`,
+which is **token-only**: the request must carry `?token=` matching
+`config('app.clear_cache_token')`. Comparison is constant-time via
+`hash_equals()`.
 
-- `APP_ENV` is `local` or `development`, OR
-- The request carries `?token=` matching the `CLEAR_CACHE_TOKEN` env var.
+Wire-up per consumer:
 
-Unauthorized requests get `401 { "status": "restricted", "message": "Not available" }`.
+1. Add to your `config/app.php`:
+
+   ```php
+   'clear_cache_token' => env('CLEAR_CACHE_TOKEN'),
+   ```
+
+2. Set `CLEAR_CACHE_TOKEN` in every environment the endpoint is reachable from
+   (production, staging, dev) and in your local `.env`.
+
+The config indirection means the value survives `php artisan config:cache`.
+
+If `config('app.clear_cache_token')` is unset or empty, every request returns
+401 (fail-closed). Unauthorized requests get
+`401 { "status": "restricted", "message": "Not available" }`.
 
 ## Surgical: `?action=forget&key=X`
 

--- a/src/Http/Controllers/Traits/AuthorizesCacheOperations.php
+++ b/src/Http/Controllers/Traits/AuthorizesCacheOperations.php
@@ -5,9 +5,11 @@ namespace NuiMarkets\LaravelSharedUtils\Http\Controllers\Traits;
 /**
  * Shared authorization gate for cache-management endpoints.
  *
- * Allows access when:
- * - APP_ENV is in the allowed list (local, development), OR
- * - The request carries a ?token= matching CLEAR_CACHE_TOKEN env var.
+ * Token-only: the request must carry `?token=` matching
+ * `config('app.clear_cache_token')`. Consumers wire this in their
+ * `config/app.php` as `'clear_cache_token' => env('CLEAR_CACHE_TOKEN')`
+ * so the value survives `php artisan config:cache`. Set the env var in
+ * every environment the endpoint is reachable from (including local `.env`).
  *
  * Used by ClearLadaAndResponseCacheController and ApplicationCacheController
  * so both endpoints share one auth contract.
@@ -16,10 +18,12 @@ trait AuthorizesCacheOperations
 {
     protected function isAuthorizedForDetailedInfo(): bool
     {
-        $allowedEnvs = ['local', 'development'];
-        $hasValidToken = request()->has('token') &&
-            request()->get('token') === env('CLEAR_CACHE_TOKEN');
+        $configured = config('app.clear_cache_token');
 
-        return in_array(env('APP_ENV'), $allowedEnvs) || $hasValidToken;
+        if (! is_string($configured) || $configured === '') {
+            return false;
+        }
+
+        return hash_equals($configured, (string) request()->get('token', ''));
     }
 }

--- a/tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php
+++ b/tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php
@@ -13,21 +13,24 @@ use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
  * Tests for ApplicationCacheController + the ?include=app delegation
  * from ClearLadaAndResponseCacheController.
  *
+ * Auth contract is token-only via AuthorizesCacheOperations: every
+ * authorized request carries ?token=$VALID_TOKEN, every unauthorized
+ * request omits it.
+ *
  * Uses the array cache driver so tests don't depend on Redis being up.
  * The driver class name is verified in the response payload as a regression
  * guard against accidentally flushing a misconfigured store.
  */
 class ApplicationCacheControllerTest extends TestCase
 {
+    private const VALID_TOKEN = 'secret_token_xyz';
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
 
         $app['router']->get('/forget', [ApplicationCacheController::class, 'forget']);
         $app['router']->get('/clear-cache', [ClearLadaAndResponseCacheController::class, 'clearCache']);
-
-        putenv('APP_ENV=local');
-        $app['config']->set('app.env', 'local');
 
         // Use array driver so the cache facade itself doesn't need Redis.
         // The /clear-cache delegation tests still touch
@@ -61,9 +64,8 @@ class ApplicationCacheControllerTest extends TestCase
     {
         parent::setUp();
 
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
+        // Token-only auth: configure once, every authorized test passes ?token=.
+        config()->set('app.clear_cache_token', self::VALID_TOKEN);
 
         // Spy logs so the controller's Log::info() calls don't try to write
         // to disk. Keeps tests portable to sandboxes / CI runners with a
@@ -86,7 +88,7 @@ class ApplicationCacheControllerTest extends TestCase
         Cache::put('lookup:countries:all', ['NZ', 'AU'], 600);
         $this->assertTrue(Cache::has('lookup:countries:all'));
 
-        $response = $this->get('/forget?key=lookup:countries:all');
+        $response = $this->get('/forget?key=lookup:countries:all&token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
         $response->assertJsonPath('detail.key', 'lookup:countries:all');
@@ -99,7 +101,7 @@ class ApplicationCacheControllerTest extends TestCase
     /** @test */
     public function forget_reports_existed_before_false_when_key_missing()
     {
-        $response = $this->get('/forget?key=cache:absent:all');
+        $response = $this->get('/forget?key=cache:absent:all&token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
         $response->assertJsonPath('detail.existed_before', false);
@@ -111,7 +113,7 @@ class ApplicationCacheControllerTest extends TestCase
     /** @test */
     public function forget_returns_422_when_key_missing()
     {
-        $response = $this->get('/forget');
+        $response = $this->get('/forget?token='.self::VALID_TOKEN);
 
         $response->assertStatus(422);
         $response->assertJson([
@@ -123,18 +125,14 @@ class ApplicationCacheControllerTest extends TestCase
     /** @test */
     public function forget_returns_422_when_key_blank()
     {
-        $response = $this->get('/forget?key=');
+        $response = $this->get('/forget?key=&token='.self::VALID_TOKEN);
 
         $response->assertStatus(422);
     }
 
     /** @test */
-    public function forget_returns_401_in_production_without_token()
+    public function forget_returns_401_without_token()
     {
-        putenv('APP_ENV=production');
-        $_ENV['APP_ENV'] = 'production';
-        $_SERVER['APP_ENV'] = 'production';
-
         $response = $this->get('/forget?key=anything');
 
         $response->assertStatus(401);
@@ -142,34 +140,25 @@ class ApplicationCacheControllerTest extends TestCase
             'status' => 'restricted',
             'message' => 'Not available',
         ]);
-
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
     }
 
     /** @test */
-    public function forget_allows_access_in_production_with_valid_token()
+    public function forget_returns_401_with_wrong_token()
     {
-        putenv('APP_ENV=production');
-        $_ENV['APP_ENV'] = 'production';
-        $_SERVER['APP_ENV'] = 'production';
+        $response = $this->get('/forget?key=anything&token=not-the-real-token');
 
-        putenv('CLEAR_CACHE_TOKEN=secret_token_xyz');
-        $_ENV['CLEAR_CACHE_TOKEN'] = 'secret_token_xyz';
+        $response->assertStatus(401);
+    }
 
-        Cache::put('something', 'value', 600);
+    /** @test */
+    public function forget_returns_401_when_clear_cache_token_unconfigured()
+    {
+        // Wipe the configured token: even a request carrying any token must fail.
+        config()->set('app.clear_cache_token', null);
 
-        $response = $this->get('/forget?key=something&token=secret_token_xyz');
+        $response = $this->get('/forget?key=anything&token=anything');
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('detail.forgotten', true);
-
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
-        putenv('CLEAR_CACHE_TOKEN');
-        unset($_ENV['CLEAR_CACHE_TOKEN']);
+        $response->assertStatus(401);
     }
 
     /** @test */
@@ -181,7 +170,7 @@ class ApplicationCacheControllerTest extends TestCase
         Cache::put('lookup:currencies:all', ['NZD'], 600);
         $this->assertTrue(Cache::has('lookup:countries:all'));
 
-        $response = $this->get('/clear-cache?include=app');
+        $response = $this->get('/clear-cache?include=app&token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
         $response->assertJsonPath('detail.app_cache.flushed', true);
@@ -197,7 +186,7 @@ class ApplicationCacheControllerTest extends TestCase
 
         Cache::put('lookup:countries:all', ['NZ'], 600);
 
-        $response = $this->get('/clear-cache');
+        $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
         $this->assertArrayNotHasKey(
@@ -212,15 +201,11 @@ class ApplicationCacheControllerTest extends TestCase
     }
 
     /** @test */
-    public function clear_cache_with_include_app_returns_401_when_unauthorized()
+    public function clear_cache_with_include_app_returns_401_without_token()
     {
         // No skipIfNoRedis() here: the auth gate returns 401 before
         // clearCache() ever touches Redis::connection('default'), so this
         // test must run even when Redis is unavailable.
-        putenv('APP_ENV=production');
-        $_ENV['APP_ENV'] = 'production';
-        $_SERVER['APP_ENV'] = 'production';
-
         Cache::put('lookup:countries:all', ['NZ'], 600);
 
         $response = $this->get('/clear-cache?include=app');
@@ -230,9 +215,5 @@ class ApplicationCacheControllerTest extends TestCase
             Cache::has('lookup:countries:all'),
             'Application cache must not be touched on a 401 response.'
         );
-
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
     }
 }

--- a/tests/Feature/Http/Controllers/ClearLadaAndResponseCacheControllerTest.php
+++ b/tests/Feature/Http/Controllers/ClearLadaAndResponseCacheControllerTest.php
@@ -7,7 +7,11 @@ use NuiMarkets\LaravelSharedUtils\Http\Controllers\ClearLadaAndResponseCacheCont
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 
 /**
- * Tests for ClearLadaAndResponseCacheController
+ * Tests for ClearLadaAndResponseCacheController.
+ *
+ * Auth contract is token-only via AuthorizesCacheOperations: every
+ * authorized request carries ?token=$VALID_TOKEN, every unauthorized
+ * request omits it (or sends a wrong value).
  *
  * NOTE: Full integration tests with actual Lada cache counting were performed manually
  * in connect-order (Laravel 8) and connect-product (Laravel 9) and verified to work correctly.
@@ -21,17 +25,14 @@ use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
  */
 class ClearLadaAndResponseCacheControllerTest extends TestCase
 {
+    private const VALID_TOKEN = 'secret_token_123';
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
 
         // Set up route for testing
         $app['router']->get('/clear-cache', [ClearLadaAndResponseCacheController::class, 'clearCache']);
-
-        // Set environment to local to allow access without token
-        // Note: Controller uses env() not config(), so we need to set the env var
-        putenv('APP_ENV=local');
-        $app['config']->set('app.env', 'local');
 
         // Configure Redis with test prefix
         $app['config']->set('database.redis.client', 'phpredis');
@@ -50,11 +51,8 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
     {
         parent::setUp();
 
-        // Set APP_ENV for controller authorization check
-        // Must be done in setUp() as env() reads at runtime
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
+        // Token-only auth: configure once, every authorized test passes ?token=.
+        config()->set('app.clear_cache_token', self::VALID_TOKEN);
 
         // Clear Redis test database before each test
         try {
@@ -81,7 +79,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
     /** @test */
     public function it_returns_correct_response_structure()
     {
-        $response = $this->get('/clear-cache');
+        $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -109,7 +107,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
     public function it_returns_zeros_when_no_cache_libraries_installed()
     {
         // Without Lada/ResponseCache installed, should return 0s
-        $response = $this->get('/clear-cache');
+        $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
 
@@ -124,7 +122,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
     /** @test */
     public function it_returns_correct_redis_prefix_in_response()
     {
-        $response = $this->get('/clear-cache');
+        $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
         $this->assertEquals('test_prefix_', $response->json('detail.prefix'));
@@ -133,7 +131,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
     /** @test */
     public function it_includes_duration_in_response()
     {
-        $response = $this->get('/clear-cache');
+        $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
         $this->assertIsNumeric($response->json('detail.duration_ms'));
@@ -143,7 +141,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
     /** @test */
     public function it_includes_correct_message_when_cache_not_available()
     {
-        $response = $this->get('/clear-cache');
+        $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
         $this->assertEquals(
@@ -153,13 +151,8 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_restricts_access_in_production_without_token()
+    public function it_restricts_access_without_token()
     {
-        // Change environment to production
-        putenv('APP_ENV=production');
-        $_ENV['APP_ENV'] = 'production';
-        $_SERVER['APP_ENV'] = 'production';
-
         $response = $this->get('/clear-cache');
 
         $response->assertStatus(401);
@@ -167,81 +160,31 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
             'status' => 'restricted',
             'message' => 'Not available',
         ]);
-
-        // Reset to local
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
-    }
-
-    /** @test */
-    public function it_allows_access_in_production_with_valid_token()
-    {
-        // Change environment to production
-        putenv('APP_ENV=production');
-        $_ENV['APP_ENV'] = 'production';
-        $_SERVER['APP_ENV'] = 'production';
-
-        // Set a token
-        putenv('CLEAR_CACHE_TOKEN=secret_token_123');
-        $_ENV['CLEAR_CACHE_TOKEN'] = 'secret_token_123';
-
-        $response = $this->get('/clear-cache?token=secret_token_123');
-
-        $response->assertStatus(200);
-        $response->assertJsonStructure(['message', 'detail']);
-
-        // Clean up
-        putenv('CLEAR_CACHE_TOKEN');
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
-        unset($_ENV['CLEAR_CACHE_TOKEN']);
-    }
-
-    /** @test */
-    public function it_allows_access_in_development_environment()
-    {
-        putenv('APP_ENV=development');
-        $_ENV['APP_ENV'] = 'development';
-        $_SERVER['APP_ENV'] = 'development';
-
-        $response = $this->get('/clear-cache');
-
-        $response->assertStatus(200);
-
-        // Reset
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
     }
 
     /** @test */
     public function it_denies_access_with_invalid_token()
     {
-        putenv('APP_ENV=production');
-        $_ENV['APP_ENV'] = 'production';
-        $_SERVER['APP_ENV'] = 'production';
-
-        putenv('CLEAR_CACHE_TOKEN=correct_token');
-        $_ENV['CLEAR_CACHE_TOKEN'] = 'correct_token';
-
         $response = $this->get('/clear-cache?token=wrong_token');
 
         $response->assertStatus(401);
+    }
 
-        // Clean up
-        putenv('APP_ENV=local');
-        $_ENV['APP_ENV'] = 'local';
-        $_SERVER['APP_ENV'] = 'local';
-        putenv('CLEAR_CACHE_TOKEN');
-        unset($_ENV['CLEAR_CACHE_TOKEN']);
+    /** @test */
+    public function it_denies_access_when_clear_cache_token_unconfigured()
+    {
+        // Wipe the configured token: even a request carrying any token must fail.
+        config()->set('app.clear_cache_token', null);
+
+        $response = $this->get('/clear-cache?token=anything');
+
+        $response->assertStatus(401);
     }
 
     /** @test */
     public function it_returns_response_cache_status()
     {
-        $response = $this->get('/clear-cache');
+        $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
 
         $response->assertStatus(200);
 


### PR DESCRIPTION
## Summary

- `AuthorizesCacheOperations::isAuthorizedForDetailedInfo()` is now token-only. Drops the `['local', 'development']` env allowlist that never matched real deployed env names (consumers use `dev`, not `development`).
- Fail-closed: when `CLEAR_CACHE_TOKEN` is unset or empty, every request returns 401, even ones carrying any token value.
- Tests rewritten for the new contract: token configured in `setUp`, every authorized request passes `?token=`, new regression tests for "without token", "wrong token", and "`CLEAR_CACHE_TOKEN` unconfigured".
- `docs/application-cache-clear.md` updated.

## Why

The env-allowlist was meant as a laptop-dev convenience but became a security bug: real deployed dev clusters (where `APP_ENV=dev`) didn't match the list, so the endpoints fell through to the token path. None of the Connect services except `connect-product` actually have `CLEAR_CACHE_TOKEN` configured, so `?action=clear-cache` has been a 401 endpoint in deployed envs for 14 months without anyone noticing. We just discovered this trying to dev-smoke the new `?action=forget` action.

Cleaner contract: one auth path, set the token everywhere it needs to be set (including local `.env`), no env-name special-casing.

## Out of scope

- `HealthCheckController` has the same pattern with a different token name (`HEALTH_CHECK_DETAILED_TOKEN`). Will be addressed in a separate follow-up to keep this scoped to the cache trait.

## Consumer impact

Every consumer must set `CLEAR_CACHE_TOKEN` in each env (including local `.env`) for `?action=clear-cache` and `?action=forget` to return 200. Without it, both return 401 (same as before, just no longer auto-passes on `APP_ENV=local`).

## Test plan

- [x] `./vendor/bin/phpunit --filter ApplicationCacheControllerTest` (10/10 pass)
- [x] `./vendor/bin/phpunit --filter ClearLadaAndResponseCacheControllerTest` (9/9 pass, all auth paths)
- [x] Full suite: `./vendor/bin/phpunit` (576/576 pass)
- [x] `./vendor/bin/pint --test` on changed files
- [ ] Smoke on connect-order dev once 0.5.3 is tagged + consumer bumps shipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated cache-clear docs to require a token query parameter and describe fail-closed behavior when the token is unset.

* **Bug Fixes**
  * Cache-clear endpoints now require a matching token in all environments; requests without a valid token return 401 with a restricted JSON payload.

* **Tests**
  * Test suite updated to exercise and enforce token-only authorization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuimarkets/nui-laravel-shared-utils/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->