### PR TITLE
feat(logging): add request.x_forwarded_for to RequestLoggingMiddleware [ Phase 3/4]

### DIFF
--- a/src/Http/Middleware/RequestLoggingMiddleware.php
+++ b/src/Http/Middleware/RequestLoggingMiddleware.php
@@ -161,6 +161,10 @@ abstract class RequestLoggingMiddleware
             LogFields::REQUEST_METHOD => $request->method(),
             LogFields::REQUEST_PATH => $request->path(),
             LogFields::REQUEST_IP => $request->ip(),
+            // Raw X-Forwarded-For header. $request->ip() returns the resolved
+            // client IP after TrustProxies; this preserves the full chain for
+            // partner-IP forensics.
+            LogFields::REQUEST_X_FORWARDED_FOR => $request->headers->get('X-Forwarded-For'),
             LogFields::REQUEST_USER_AGENT => $request->userAgent(),
             LogFields::SENTRY_REPLAY_ID => $request->headers->get('X-Sentry-Replay-Id'),
         ];
@@ -253,6 +257,7 @@ abstract class RequestLoggingMiddleware
             LogFields::REQUEST_METHOD => $request->method(),
             LogFields::REQUEST_PATH => $request->path(),
             LogFields::REQUEST_IP => $request->ip(),
+            LogFields::REQUEST_X_FORWARDED_FOR => $request->headers->get('X-Forwarded-For'),
             LogFields::REQUEST_USER_AGENT => $request->userAgent(),
             'route_name' => $request->route() ? $request->route()->getName() : 'unknown',
         ];

--- a/src/Logging/LogFields.php
+++ b/src/Logging/LogFields.php
@@ -42,6 +42,11 @@ abstract class LogFields
 
     const REQUEST_IP = 'request.ip'; // PII: Contains IP address
 
+    // Raw X-Forwarded-For chain (keyword, comma-separated) for partner-IP
+    // forensics and credential-abuse correlation. Distinct from REQUEST_IP
+    // which is post-TrustProxies and a single resolved client IP.
+    const REQUEST_X_FORWARDED_FOR = 'request.x_forwarded_for'; // PII: May contain IP addresses
+
     const REQUEST_USER_AGENT = 'request.user_agent';
 
     const REQUEST_HEADERS = 'request.headers';
@@ -257,6 +262,7 @@ abstract class LogFields
                 'RESPONSE_STATUS' => self::RESPONSE_STATUS,
                 // Basic request properties
                 'REQUEST_IP' => self::REQUEST_IP,
+                'REQUEST_X_FORWARDED_FOR' => self::REQUEST_X_FORWARDED_FOR,
                 'REQUEST_USER_AGENT' => self::REQUEST_USER_AGENT,
                 // User context from JWT/session
                 'REQUEST_USER_ID' => self::REQUEST_USER_ID,
@@ -377,6 +383,7 @@ abstract class LogFields
     {
         return [
             'REQUEST_IP' => self::REQUEST_IP,
+            'REQUEST_X_FORWARDED_FOR' => self::REQUEST_X_FORWARDED_FOR,
             'REQUEST_USER_ID' => self::REQUEST_USER_ID,
             'REQUEST_USER_EMAIL' => self::REQUEST_USER_EMAIL,
             'USER_ID' => self::USER_ID,

--- a/src/Logging/SensitiveDataProcessor.php
+++ b/src/Logging/SensitiveDataProcessor.php
@@ -52,6 +52,7 @@ class SensitiveDataProcessor
         'remote_ip',
         'request.ip',   // LogFields constant
         '.ip',          // Catches request.ip, user.ip, etc.
+        'x_forwarded_for', // Raw XFF chain may carry one-or-more IP addresses
 
         // Personal Identifiers (commonly used)
         'user_id',      // User identifiers are PII

--- a/tests/Unit/Http/Middleware/RequestLoggingMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/RequestLoggingMiddlewareTest.php
@@ -46,6 +46,44 @@ class RequestLoggingMiddlewareTest extends TestCase
         );
     }
 
+    public function test_logs_x_forwarded_for_header_when_present()
+    {
+        // The raw X-Forwarded-For chain is logged for partner-IP forensics.
+        $request = Request::create('/api/orders', 'GET');
+        $request->headers->set('X-Forwarded-For', '203.0.113.42, 198.51.100.7');
+
+        $response = new Response('OK', 200);
+
+        $this->middleware->handle($request, function ($req) use ($response) {
+            return $response;
+        });
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return ($context['request.x_forwarded_for'] ?? null) === '203.0.113.42, 198.51.100.7';
+            })
+        );
+    }
+
+    public function test_logs_null_x_forwarded_for_when_header_absent()
+    {
+        // Missing header normalizes to null (Laravel skips null values in log context).
+        $request = Request::create('/api/orders', 'GET');
+
+        $response = new Response('OK', 200);
+
+        $this->middleware->handle($request, function ($req) use ($response) {
+            return $response;
+        });
+
+        Log::shouldHaveReceived('withContext')->once()->with(
+            \Mockery::on(function ($context) {
+                return array_key_exists('request.x_forwarded_for', $context)
+                    && $context['request.x_forwarded_for'] === null;
+            })
+        );
+    }
+
     public function test_generates_request_id_if_not_provided()
     {
         // Mock Str::uuid to return a predictable value

--- a/tests/Unit/Logging/SensitiveDataProcessorTest.php
+++ b/tests/Unit/Logging/SensitiveDataProcessorTest.php
@@ -130,6 +130,25 @@ class SensitiveDataProcessorTest extends TestCase
         $this->assertEquals('[REDACTED]', $processed['context']['request']['user']['credentials']['api_token']);
     }
 
+    public function test_redacts_x_forwarded_for_chain()
+    {
+        // The raw X-Forwarded-For chain carries one-or-more IPs and is flagged
+        // PII by LogFields::REQUEST_X_FORWARDED_FOR. Matched via substring on
+        // 'x_forwarded_for' so the LogFields-style 'request.x_forwarded_for'
+        // and any future variant both get redacted.
+        $record = $this->createLogRecord([
+            'request.x_forwarded_for' => '203.0.113.42, 198.51.100.7',
+            'metadata' => [
+                'x_forwarded_for' => '198.51.100.99',
+            ],
+        ]);
+
+        $processed = $this->processor->__invoke($record);
+
+        $this->assertEquals('[REDACTED]', $processed['context']['request.x_forwarded_for']);
+        $this->assertEquals('[REDACTED]', $processed['context']['metadata']['x_forwarded_for']);
+    }
+
     public function test_preserves_non_sensitive_data()
     {
         $record = $this->createLogRecord([


### PR DESCRIPTION
## Summary
Add \`LogFields::REQUEST_X_FORWARDED_FOR\` constant (\`request.x_forwarded_for\`, flagged PII) and emit it from both \`buildBaseContext()\` and \`logRequestStart()\` in \`RequestLoggingMiddleware\`.

## Why
\`\$request->ip()\` returns the single resolved client IP (post-TrustProxies), which is enough for most purposes but loses the proxy chain. For partner-IP forensics (NAT, ALB, CloudFront in front), we need both: the resolved IP for indexing/correlation, and the raw chain for chain inspection.


## Backwards compatibility
- **Additive**: new constant + new log field. Existing constants and behavior unchanged.
- **Dependency**: logging the chain requires \`TrustProxies\` middleware registered upstream of \`RequestLoggingMiddleware\` so \`\$request->ip()\` resolves to the real client IP. 
- Listed in \`getPiiFields()\` because the header may carry IP addresses.

## Test plan
- [x] \`vendor/bin/phpunit tests/Unit/Http/Middleware/RequestLoggingMiddlewareTest.php\` exits 0 (29/29 pass; 2 new tests for present + absent header)
- [x] \`vendor/bin/phpunit tests/Unit/Logging/LogFieldsTest.php\` exits 0 (6/6 pass)
- [x] Full suite \`vendor/bin/phpunit\` exits 0 modulo pre-existing env errors (Redis connection, Intervention/Image missing) unrelated to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Request logging now captures the raw X-Forwarded-For header and includes it in structured request logs.
  * X-Forwarded-For is treated as potentially sensitive and will be redacted when PII redaction is enabled.

* **Tests**
  * Added unit tests covering X-Forwarded-For logging behavior and its redaction handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuimarkets/nui-laravel-shared-utils/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->