### PR TITLE
fix(health): probe only allowlisted DB connections (Laravel 11)

### DIFF
--- a/src/Http/Controllers/HealthCheckController.php
+++ b/src/Http/Controllers/HealthCheckController.php
@@ -75,7 +75,14 @@ class HealthCheckController extends Controller
 
         // Database checks (MySQL, PostgreSQL, etc.)
         if (file_exists(config_path('database.php')) && config('database.connections')) {
-            foreach (config('database.connections') as $connName => $connConfig) {
+            foreach ($this->resolveHealthCheckConnections() as $connName) {
+                $connConfig = config("database.connections.{$connName}");
+
+                // Skip connections that aren't actually configured
+                if (! is_array($connConfig)) {
+                    continue;
+                }
+
                 // skip any testing schemas
                 if (Str::contains($connName, 'test')) {
                     continue;
@@ -118,6 +125,37 @@ class HealthCheckController extends Controller
         }
 
         return new JsonResponse($results, 200);
+    }
+
+    /**
+     * Resolve which database connections the health check should probe.
+     *
+     * Laravel 11 deep-merges the framework's default `database.connections`
+     * (sqlite, mariadb, pgsql, sqlsrv) into every app's config, so iterating
+     * the full connection list now probes stub connections the app never
+     * uses - e.g. a pgsql stub pointing at 127.0.0.1:5432 - producing false
+     * "connection failed" errors. To stay explicit, consumers list the
+     * connections they actually want monitored:
+     *
+     *     // config/health-check.php
+     *     return ['connections' => ['mysql', 'fields']];
+     *
+     * When unset, only the default connection is probed (the one connection
+     * guaranteed to be intentional).
+     *
+     * @return string[]
+     */
+    protected function resolveHealthCheckConnections(): array
+    {
+        $configured = config('health-check.connections');
+
+        if (is_array($configured) && $configured !== []) {
+            return array_values($configured);
+        }
+
+        $default = config('database.default');
+
+        return $default ? [$default] : [];
     }
 
     /**

--- a/tests/Feature/Http/Controllers/HealthCheckControllerTest.php
+++ b/tests/Feature/Http/Controllers/HealthCheckControllerTest.php
@@ -141,6 +141,53 @@ class HealthCheckControllerTest extends TestCase
         $this->assertEquals('ok', $data['status']);
     }
 
+    public function test_merged_framework_default_connection_not_probed_without_allowlist()
+    {
+        // Reproduces the Laravel 11 behaviour where the framework's default
+        // connections (pgsql, sqlsrv, ...) are deep-merged into every app's
+        // database.connections. Without an explicit allowlist, the health
+        // check must only probe the default connection and leave the merged
+        // pgsql stub alone - otherwise it reports a spurious connection error.
+        config()->set('database.connections.pgsql', [
+            'driver' => 'pgsql',
+            'host' => '127.0.0.1',
+            'port' => 5432,
+            'database' => 'unreachable',
+            'username' => 'nobody',
+            'password' => 'nobody',
+        ]);
+        config()->set('health-check.connections', null);
+
+        $response = $this->get('/healthcheck');
+
+        $data = $response->json();
+
+        $this->assertArrayNotHasKey('pgsql', $data['checks']);
+        $this->assertEquals('ok', $data['status']);
+    }
+
+    public function test_allowlisted_connection_is_probed()
+    {
+        // When a connection is explicitly allowlisted it must be probed, even
+        // if that surfaces a real connection failure (the point of the check).
+        config()->set('database.connections.pgsql', [
+            'driver' => 'pgsql',
+            'host' => '127.0.0.1',
+            'port' => 5432,
+            'database' => 'unreachable',
+            'username' => 'nobody',
+            'password' => 'nobody',
+        ]);
+        config()->set('health-check.connections', ['pgsql']);
+
+        $response = $this->get('/healthcheck');
+
+        $data = $response->json();
+
+        $this->assertArrayHasKey('pgsql', $data['checks']);
+        $this->assertEquals('error', $data['checks']['pgsql']['status']);
+    }
+
     public function test_health_check_shows_all_checks_structure()
     {
         $response = $this->get('/healthcheck');


### PR DESCRIPTION
## Summary
- Laravel 11 deep-merges the framework's default DB connections (`pgsql`, `sqlsrv`, `sqlite`, `mariadb`) into every app's `config('database.connections')`, so `HealthCheckController::detailed()` probed a `pgsql` stub no service configured and reported a false `PostgreSQL connection error for [pgsql]`. The health-check code didn't change; its input did (Laravel 9 had no base-config merge).
- Health check now probes only the connections in `config('health-check.connections')`, falling back to `config('database.default')` when that key is unset.
- Adds regression tests covering both the merged-stub-not-probed case and the explicitly-allowlisted-connection-probed case.

## Review
Internal: clean. External (Codex): 1 P2 noted (see migration note below), nothing applied.

## Migration note (for consumers)
This changes the default from "probe every configured connection" to "probe only the default connection". A service with multiple real connections must add `config/health-check.php`:

\`\`\`php
return ['connections' => ['mysql', 'fields']];
\`\`\`

Otherwise only its default connection is health-checked. This is the deliberate trade-off to stop probing the Laravel 11 framework-default stubs. connect-order's companion PR adds its allowlist (CON-2152).

## Changes
- `src/Http/Controllers/HealthCheckController.php` (+39 -1)
- `tests/Feature/Http/Controllers/HealthCheckControllerTest.php` (+47)

## Test plan
- [x] `vendor/bin/phpunit --filter HealthCheckControllerTest` - 8 passed, 43 assertions
- [x] Pint clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health checks can be configured to probe specific database connections rather than all of them.

* **Bug Fixes**
  * Health checks no longer probe every database connection by default, reducing false failures when unused connections are unreachable.

* **Tests**
  * Added feature tests covering allowlisted connection probing and omission when the connection list is unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->