### PR TITLE
fix(tests): repair red master CI (Laravel 11 + prefer-lowest)

### DIFF
--- a/tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php
+++ b/tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php
@@ -70,7 +70,12 @@ class ApplicationCacheControllerTest extends TestCase
         // Spy logs so the controller's Log::info() calls don't try to write
         // to disk. Keeps tests portable to sandboxes / CI runners with a
         // read-only filesystem under vendor/.
-        Log::spy();
+        //
+        // Stub channel() to return the spy: PHP deprecations raised mid-request
+        // (common on the prefer-lowest dependency floor) are routed by Laravel
+        // through $logger->channel('deprecations')->warning(), which would
+        // otherwise call warning() on the spy's null channel() and 500.
+        Log::spy()->shouldReceive('channel')->andReturnSelf();
 
         Cache::store()->flush();
     }

--- a/tests/Unit/Logging/SensitiveDataProcessorTest.php
+++ b/tests/Unit/Logging/SensitiveDataProcessorTest.php
@@ -113,7 +113,7 @@ class SensitiveDataProcessorTest extends TestCase
         // PII by LogFields::REQUEST_X_FORWARDED_FOR. Matched via substring on
         // 'x_forwarded_for' so the LogFields-style 'request.x_forwarded_for'
         // and any future variant both get redacted.
-        $record = $this->createLogRecord([
+        $record = $this->createMonolog3Record(context: [
             'request.x_forwarded_for' => '203.0.113.42, 198.51.100.7',
             'metadata' => [
                 'x_forwarded_for' => '198.51.100.99',


### PR DESCRIPTION
## Summary
Master CI was red on every matrix leg. Two independent test-only failures, both surfaced by the Laravel 11 upgrade:

1. **Stale `createLogRecord` helper** (all legs) - `SensitiveDataProcessorTest::test_redacts_x_forwarded_for_chain` called `$this->createLogRecord(...)`, a helper renamed to `createMonolog3Record()` during the Monolog 3 / L11 work; the one call site was missed. Repointed to `createMonolog3Record(context: ...)`.

2. **`Log::spy()` + deprecations** (Laravel 11 prefer-lowest leg, 7 × `ApplicationCacheControllerTest` 500s) - floor-version dependencies emit PHP deprecations during the request, which Laravel routes through `$logger->channel('deprecations')->warning()`. The test's `Log::spy()` didn't stub `channel()`, so it returned `null` and `warning()` fataled - turning every asserted 401/422/200 into a 500. prefer-stable passes only because current deps don't emit those deprecations. Fixed by stubbing `channel()` to return the spy.

Both are test-only; no production code changes.

## Changes
- `tests/Unit/Logging/SensitiveDataProcessorTest.php` (1 line)
- `tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php` (Log spy channel stub)

## Test plan
- [x] `SensitiveDataProcessorTest` - 15 passed
- [x] `ApplicationCacheControllerTest` on a replicated prefer-lowest Laravel 11 install - 10 passed (was 7 × 500)
- [ ] CI: all matrix legs green (the point of this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted how a sensitive-data test constructs its log record to use the updated Monolog record helper, preserving existing expected payloads.
  * Updated a controller test’s logger spy to stub channel behavior, preventing deprecation warnings from causing errors during test execution.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->