### PR TITLE
perf(cache): flush lada-cache via non-blocking SCAN instead of KEYS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,11 @@
   "config": {
     "allow-plugins": {
       "php-http/discovery": true
+    },
+    "audit": {
+      "ignore": {
+        "CVE-2026-48019": "CRLF injection in Laravel's default email rule. No 10.x/11.x backport exists yet (fixed only in 12.60+/13.10+), so it blocks all installs in our ^10.15|^11.0 range. Remove once an 11.x patch ships."
+      }
     }
   }
 }

--- a/src/Http/Controllers/ClearLadaAndResponseCacheController.php
+++ b/src/Http/Controllers/ClearLadaAndResponseCacheController.php
@@ -5,7 +5,6 @@ namespace NuiMarkets\LaravelSharedUtils\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
 use NuiMarkets\LaravelSharedUtils\Http\Controllers\Traits\AuthorizesCacheOperations;
@@ -16,6 +15,12 @@ use NuiMarkets\LaravelSharedUtils\Http\Controllers\Traits\AuthorizesCacheOperati
 class ClearLadaAndResponseCacheController extends Controller
 {
     use AuthorizesCacheOperations;
+
+    /**
+     * Keys scanned (and deleted) per SCAN iteration. Bounds both the cursor
+     * batch size and the UNLINK argument list.
+     */
+    private const SCAN_COUNT = 1000;
 
     /**
      * clears lada-cache and response-cache. With ?include=app, also flushes
@@ -36,40 +41,31 @@ class ClearLadaAndResponseCacheController extends Controller
 
         $dbIndex = config('database.redis.default.database');
 
-        $prefix = config('database.redis.options.prefix');
+        // Cast: the prefix is optional, and a null would trip str_starts_with()
+        // in the scan helpers under PHP 8.x. An empty string disables stripping.
+        $prefix = (string) config('database.redis.options.prefix');
         $ladaPrefix = config('lada-cache.prefix', 'lada:');
-
-        // Laravel's Redis connection automatically adds the prefix when using keys()
-        // So we only search for the lada prefix pattern
-        $ladaPattern = $ladaPrefix.'*';
 
         $ladaAvailable = class_exists('Spiritix\LadaCache\Cache');
         $responseCacheAvailable = class_exists('Spatie\ResponseCache\Facades\ResponseCache');
 
-        // Get lada key counts before clearing (queries + tags)
-        $ladaKeysBefore = $ladaAvailable
-            ? $connection->keys($ladaPattern)
-            : [];
-
-        // Separate query cache from tag keys
-        $ladaQueriesBefore = array_filter($ladaKeysBefore, function ($key) use ($prefix, $ladaPrefix) {
-            // Tags are stored as sets with format: {prefix}lada:tag:{table}
-            // Queries are stored as strings with format: {prefix}lada:query:{hash}
-            $keyWithoutPrefix = str_replace($prefix.$ladaPrefix, '', $key);
-
-            return ! str_starts_with($keyWithoutPrefix, 'tag:');
-        });
-
-        $ladaTagsBefore = array_filter($ladaKeysBefore, function ($key) use ($prefix, $ladaPrefix) {
-            $keyWithoutPrefix = str_replace($prefix.$ladaPrefix, '', $key);
-
-            return str_starts_with($keyWithoutPrefix, 'tag:');
-        });
-
         $start = microtime(true);
 
+        $queriesBefore = 0;
+        $tagsBefore = 0;
+        $queriesCleared = 0;
+        $tagsCleared = 0;
+        $queriesAfter = 0;
+        $tagsAfter = 0;
+
         if ($ladaAvailable) {
-            Artisan::call('lada-cache:flush');
+            // Three independent snapshots so every figure is a real measurement:
+            // count what exists, the sweep's own removal count, then count what
+            // remains. Under concurrent writes these need not reconcile exactly
+            // (before - after == cleared), but none is inferred from another.
+            [$queriesBefore, $tagsBefore] = $this->countLadaKeys($connection, $prefix, $ladaPrefix);
+            [$queriesCleared, $tagsCleared] = $this->clearLadaKeys($connection, $prefix, $ladaPrefix);
+            [$queriesAfter, $tagsAfter] = $this->countLadaKeys($connection, $prefix, $ladaPrefix);
         }
 
         if ($responseCacheAvailable) {
@@ -79,22 +75,9 @@ class ClearLadaAndResponseCacheController extends Controller
 
         $durationMs = round((microtime(true) - $start) * 1000, 2);
 
-        // Get lada key counts after clearing
-        $ladaKeysAfter = $ladaAvailable
-            ? $connection->keys($ladaPattern)
-            : [];
-
-        $ladaQueriesAfter = array_filter($ladaKeysAfter, function ($key) use ($prefix, $ladaPrefix) {
-            $keyWithoutPrefix = str_replace($prefix.$ladaPrefix, '', $key);
-
-            return ! str_starts_with($keyWithoutPrefix, 'tag:');
-        });
-
-        $ladaTagsAfter = array_filter($ladaKeysAfter, function ($key) use ($prefix, $ladaPrefix) {
-            $keyWithoutPrefix = str_replace($prefix.$ladaPrefix, '', $key);
-
-            return str_starts_with($keyWithoutPrefix, 'tag:');
-        });
+        $totalBefore = $queriesBefore + $tagsBefore;
+        $totalCleared = $queriesCleared + $tagsCleared;
+        $totalAfter = $queriesAfter + $tagsAfter;
 
         $msg = 'Cache clearing skipped. Lada and response caching not found';
 
@@ -114,19 +97,19 @@ class ClearLadaAndResponseCacheController extends Controller
             'summary' => [
                 'lada_cache' => [
                     'total_keys' => [
-                        'before' => count($ladaKeysBefore),
-                        'after' => count($ladaKeysAfter),
-                        'cleared' => count($ladaKeysBefore) - count($ladaKeysAfter),
+                        'before' => $totalBefore,
+                        'after' => $totalAfter,
+                        'cleared' => $totalCleared,
                     ],
                     'cached_queries' => [
-                        'before' => count($ladaQueriesBefore),
-                        'after' => count($ladaQueriesAfter),
-                        'cleared' => count($ladaQueriesBefore) - count($ladaQueriesAfter),
+                        'before' => $queriesBefore,
+                        'after' => $queriesAfter,
+                        'cleared' => $queriesCleared,
                     ],
                     'tag_keys' => [
-                        'before' => count($ladaTagsBefore),
-                        'after' => count($ladaTagsAfter),
-                        'cleared' => count($ladaTagsBefore) - count($ladaTagsAfter),
+                        'before' => $tagsBefore,
+                        'after' => $tagsAfter,
+                        'cleared' => $tagsCleared,
                     ],
                 ],
                 'response_cache' => [
@@ -148,5 +131,99 @@ class ClearLadaAndResponseCacheController extends Controller
             'detail' => $detail,
         ]);
 
+    }
+
+    /**
+     * Delete every lada-cache key via UNLINK and return how many of each type
+     * were swept (SCAN may surface a key twice; UNLINK on an already-removed
+     * key is a no-op, so a rare duplicate is counted but not double-deleted).
+     *
+     * Used in place of the package's KEYS-based flush(), which blocks
+     * single-threaded Redis for an O(keyspace) scan on every call. The cursor
+     * SCAN underneath yields between batches, so the server is never frozen;
+     * UNLINK frees memory off the main thread.
+     *
+     * @return array{0:int,1:int} [queryCount, tagCount]
+     */
+    private function clearLadaKeys($connection, string $prefix, string $ladaPrefix): array
+    {
+        $tagMarker = $ladaPrefix.'tags:';
+        $queryCount = 0;
+        $tagCount = 0;
+        $batch = [];
+
+        foreach ($this->scanLadaKeys($connection, $prefix, $ladaPrefix) as $ladaKey) {
+            str_starts_with($ladaKey, $tagMarker) ? $tagCount++ : $queryCount++;
+
+            $batch[] = $ladaKey;
+
+            if (count($batch) >= self::SCAN_COUNT) {
+                $connection->unlink(...$batch);
+                $batch = [];
+            }
+        }
+
+        if ($batch !== []) {
+            $connection->unlink(...$batch);
+        }
+
+        return [$queryCount, $tagCount];
+    }
+
+    /**
+     * Count lada-cache keys by type without modifying Redis. Used for the
+     * post-clear "after" figure.
+     *
+     * @return array{0:int,1:int} [queryCount, tagCount]
+     */
+    private function countLadaKeys($connection, string $prefix, string $ladaPrefix): array
+    {
+        $tagMarker = $ladaPrefix.'tags:';
+        $queryCount = 0;
+        $tagCount = 0;
+
+        foreach ($this->scanLadaKeys($connection, $prefix, $ladaPrefix) as $ladaKey) {
+            str_starts_with($ladaKey, $tagMarker) ? $tagCount++ : $queryCount++;
+        }
+
+        return [$queryCount, $tagCount];
+    }
+
+    /**
+     * Walk all lada-cache keys with a non-blocking cursor SCAN, yielding each in
+     * its lada-relative form (connection prefix stripped).
+     *
+     * Lada caches query results as `{prefix}lada:{md5}` strings and invalidation
+     * tags as `{prefix}lada:tags:...` sets, so a yielded key starting with
+     * `{ladaPrefix}tags:` is a tag and the rest are queries. SCAN may surface the
+     * same key twice, which callers tolerate (UNLINK is idempotent).
+     *
+     * @return \Generator<string>
+     */
+    private function scanLadaKeys($connection, string $prefix, string $ladaPrefix): \Generator
+    {
+        // phpredis does not auto-prefix a SCAN MATCH (keys() does), so add it here.
+        $pattern = $prefix.$ladaPrefix.'*';
+
+        // Must start null, not 0 - phpredis returns nothing for an integer-0 cursor.
+        $cursor = null;
+
+        do {
+            $response = $connection->scan($cursor, ['match' => $pattern, 'count' => self::SCAN_COUNT]);
+
+            if ($response === false) {
+                break;
+            }
+
+            [$cursor, $keys] = $response;
+
+            foreach ((array) $keys as $key) {
+                // Normalise to the lada-relative form: results may or may not carry
+                // the connection prefix, and UNLINK re-applies it.
+                yield ($prefix !== '' && str_starts_with($key, $prefix))
+                    ? substr($key, strlen($prefix))
+                    : $key;
+            }
+        } while ((int) $cursor !== 0);
     }
 }

--- a/tests/Feature/Http/Controllers/ClearLadaAndResponseCacheControllerTest.php
+++ b/tests/Feature/Http/Controllers/ClearLadaAndResponseCacheControllerTest.php
@@ -192,4 +192,86 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         $this->assertEquals('not available', $responseCache['cleared']);
         $this->assertStringContainsString('Laravel cache tags', $responseCache['note']);
     }
+
+    /**
+     * Exercises the SCAN helper directly against a real Redis. The controller
+     * gates it behind class_exists('Spiritix\LadaCache\Cache'), which is not
+     * installed in this package's test suite, so we invoke the private helper to
+     * verify cursor/prefix handling, query-vs-tag classification, count-only vs
+     * delete modes, and that unrelated keys survive.
+     *
+     * @test
+     */
+    public function it_scans_and_clears_only_lada_keys()
+    {
+        $connection = Redis::connection('default');
+
+        // Lada query results: strings keyed {prefix}lada:{md5}.
+        $connection->set('lada:'.md5('query-one'), 'cached-result-1');
+        $connection->set('lada:'.md5('query-two'), 'cached-result-2');
+
+        // Lada invalidation tag: a set keyed {prefix}lada:tags:database:...
+        $connection->sadd('lada:tags:database:Orders:table_specific:orders', 'lada:'.md5('query-one'));
+
+        // Non-lada key that must survive the sweep.
+        $connection->set('responsecache:keep', 'do-not-delete');
+
+        $controller = new ClearLadaAndResponseCacheController;
+        $countLadaKeys = new \ReflectionMethod($controller, 'countLadaKeys');
+        $countLadaKeys->setAccessible(true);
+        $clearLadaKeys = new \ReflectionMethod($controller, 'clearLadaKeys');
+        $clearLadaKeys->setAccessible(true);
+
+        // countLadaKeys must not remove anything.
+        [$queries, $tags] = $countLadaKeys->invoke($controller, $connection, 'test_prefix_', 'lada:');
+        $this->assertSame(2, $queries);
+        $this->assertSame(1, $tags);
+        $this->assertSame(1, $connection->exists('lada:'.md5('query-one')));
+
+        // clearLadaKeys reports the same counts and removes them.
+        [$queries, $tags] = $clearLadaKeys->invoke($controller, $connection, 'test_prefix_', 'lada:');
+        $this->assertSame(2, $queries);
+        $this->assertSame(1, $tags);
+
+        $this->assertSame(0, $connection->exists('lada:'.md5('query-one')));
+        $this->assertSame(0, $connection->exists('lada:'.md5('query-two')));
+        $this->assertSame(0, $connection->exists('lada:tags:database:Orders:table_specific:orders'));
+        $this->assertSame(1, $connection->exists('responsecache:keep'));
+
+        // A follow-up count returns zero - the honest "after" the controller reports.
+        [$queries, $tags] = $countLadaKeys->invoke($controller, $connection, 'test_prefix_', 'lada:');
+        $this->assertSame(0, $queries);
+        $this->assertSame(0, $tags);
+    }
+
+    /**
+     * Seeds more than SCAN_COUNT (1000) keys so the sweep spans multiple cursor
+     * iterations and triggers the mid-loop UNLINK batch flush, not just the
+     * trailing remainder. Guards the batching boundary the small test misses.
+     *
+     * @test
+     */
+    public function it_clears_lada_keys_across_multiple_scan_batches()
+    {
+        $connection = Redis::connection('default');
+
+        $total = 1100;
+        $connection->pipeline(function ($pipe) use ($total) {
+            for ($i = 0; $i < $total; $i++) {
+                $pipe->set('lada:'.md5('bulk-'.$i), '1');
+            }
+        });
+
+        $controller = new ClearLadaAndResponseCacheController;
+        $clearLadaKeys = new \ReflectionMethod($controller, 'clearLadaKeys');
+        $clearLadaKeys->setAccessible(true);
+
+        [$queries, $tags] = $clearLadaKeys->invoke($controller, $connection, 'test_prefix_', 'lada:');
+
+        $this->assertSame($total, $queries);
+        $this->assertSame(0, $tags);
+
+        // Nothing matching the lada pattern survives the multi-batch sweep.
+        $this->assertSame([], $connection->keys('lada:*'));
+    }
 }


### PR DESCRIPTION
## Summary

- `ClearLadaAndResponseCacheController` ran three blocking `KEYS` scans per request (count-before, the package's KEYS-based flush, count-after). `KEYS` is O(total keyspace) and blocks single-threaded Redis for its full duration, so on a large shared DB each clear-cache call caused a multi-millisecond global stall affecting every other client.
- Replace them with cursor `SCAN`: a private `scanLadaKeys()` generator holds the SCAN/cursor/prefix logic, with explicit `clearLadaKeys()` (UNLINK sweep) and `countLadaKeys()` (read-only) built on it. SCAN yields between batches so the server is never frozen; UNLINK frees memory off the main thread.
- Fix query-vs-tag classification: lada tags are keyed `lada:tags:` (Tagger `PREFIX_DATABASE`), not `lada:tag:`, so the previous check classified every key as a query and reported zero tags.
- Report `before`/`after`/`cleared` as three independent snapshots (count, sweep removal count, count) rather than inferring any field from another - no fabricated or negative values. The response shape is unchanged.

## Review

Internal: 2 correctness fixes (negative `cleared` under concurrency; null-prefix `str_starts_with` on PHP 8.x) + polish. External (Codex): coherent before/after/cleared semantics + multi-batch test coverage applied; SCAN-duplicate count nuance documented.

## Changes

```
 .../ClearLadaAndResponseCacheController.php        | 181 +++++++++++++++------
 .../ClearLadaAndResponseCacheControllerTest.php    |  82 ++++++++++
 2 files changed, 211 insertions(+), 52 deletions(-)
```

## Test plan

- [x] New real-Redis tests: count-only leaves keys intact; clear removes them and reports counts; classification correct; unrelated keys survive; `after` == 0; a >1000-key seed exercises multi-batch cursor + the UNLINK batch-flush boundary
- [x] Full suite: 577/577 pass
- [x] Pint: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache clearing reliability and performance by switching to non-blocking Redis sweep/delete operations.

* **New Features**
  * Cache-clearing endpoint now reports detailed before/after/cleared metrics for different key categories.

* **Tests**
  * Added integration tests validating sweeping across large key sets, batched deletions, and preservation of unrelated keys.

* **Chores**
  * Composer audit config adjusted to avoid a blocking advisory for supported installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also in this PR: CI unblock (`build(composer)` commit)

A FriendsOfPHP advisory entry for **CVE-2026-48019** (CRLF in Laravel's default email rule) landed in Composer's feed on 2026-06-03, marking all 9.x/10.x/11.x affected with a fix only in 12.60+/13.10+. With no advisory-clean version in the `^10.15|^11.0` range, Composer's default blocking failed every CI job at the install step. Added a targeted `config.audit.ignore` for this one CVE (not a blanket disable), to be removed once an 11.x backport ships.