### PR TITLE
feat(health): standardize home endpoint response shape

### DIFF
--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -4,7 +4,6 @@ namespace NuiMarkets\LaravelSharedUtils\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Log;
 
 /**
  * Home Route (hello/health check)
@@ -13,21 +12,17 @@ class HomeController extends Controller
 {
     public function home(): JsonResponse
     {
-        $service = config('app.name').'.'.config('app.env');
-
-        Log::info('home info', ['service' => $service]);
-
         $results = [
-            'message' => $service,
+            'status' => 'ok',
+            'service' => config('app.name').'.'.config('app.env'),
+            'git_tag' => env('GIT_TAG'),
         ];
 
         // Only add debug info if app.debug is set to true
         if (config('app.debug') === true) {
             $results['debug'] = true;
-            $results['app_url'] = env('APP_URL');
         }
 
         return new JsonResponse($results, 200);
-
     }
 }

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Feature\Http\Controllers;
+
+use NuiMarkets\LaravelSharedUtils\Http\Controllers\HomeController;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+/**
+ * Tests for the basic health endpoint (GET /) response shape.
+ *
+ * Asserts the standardized payload (status / service / git_tag), the
+ * debug-only conditional, and guards against the old shape leaking back
+ * (no `message`, no `app_url`).
+ */
+class HomeControllerTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['router']->get('/', [HomeController::class, 'home']);
+
+        // Deterministic service string for assertions.
+        $app['config']->set('app.name', 'example-service');
+        $app['config']->set('app.env', 'prod');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('GIT_TAG');
+        unset($_ENV['GIT_TAG'], $_SERVER['GIT_TAG']);
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_returns_the_standardized_health_payload()
+    {
+        putenv('GIT_TAG=v6.8.0');
+        $_ENV['GIT_TAG'] = 'v6.8.0';
+
+        config()->set('app.debug', false);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('status', 'ok');
+        $response->assertJsonPath('service', 'example-service.prod');
+        $response->assertJsonPath('git_tag', 'v6.8.0');
+    }
+
+    /** @test */
+    public function it_returns_a_null_git_tag_when_unset()
+    {
+        // Explicitly clear so the test is deterministic regardless of test
+        // order or an ambient GIT_TAG in the CI environment.
+        putenv('GIT_TAG');
+        unset($_ENV['GIT_TAG'], $_SERVER['GIT_TAG']);
+
+        config()->set('app.debug', false);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        // The key is always present; value is null when the env var is absent.
+        $this->assertArrayHasKey('git_tag', $response->json());
+        $response->assertJsonPath('git_tag', null);
+    }
+
+    /** @test */
+    public function it_omits_debug_when_app_debug_is_false()
+    {
+        config()->set('app.debug', false);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $this->assertArrayNotHasKey('debug', $response->json());
+    }
+
+    /** @test */
+    public function it_includes_debug_when_app_debug_is_true()
+    {
+        config()->set('app.debug', true);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('debug', true);
+    }
+
+    /** @test */
+    public function it_does_not_leak_the_old_response_shape()
+    {
+        config()->set('app.debug', true);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $payload = $response->json();
+        $this->assertArrayNotHasKey('message', $payload);
+        $this->assertArrayNotHasKey('app_url', $payload);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `status` field to the `GET /` payload so monitors and load balancers can assert health with a single key
- Expose the deployed release via `git_tag` (from the `GIT_TAG` env) for at-a-glance version checks; the key is always present (null when unset), consistent with how `EnvironmentProcessor` and the detailed health check already emit it
- Rename `message` to `service` for clearer semantics
- Drop `app_url` from the payload (no longer exposes the configured app URL) and remove the per-request "home info" log line that fired on every health-check hit
- Keep `debug: true` gated behind `app.debug`

## Compatibility
Breaking change to the `GET /` response shape (`message` removed, `app_url` removed). This is a base health/hello endpoint; consumers should adopt on the next release. No internal callers in this package depend on the old keys or the removed log line.

## Review
Internal: clean. External (Codex: clean; Kimi-agentic: 1 test-coverage gap applied, breaking-shape change is intended, CHANGELOG noted).

## Changes
- `src/Http/Controllers/HomeController.php` (+3, -8)
- `tests/Feature/Http/Controllers/HomeControllerTest.php` (new)

## Test plan
- [x] 5 feature tests: payload shape, null `git_tag` when unset, debug on/off conditional, old-shape regression guard
- [x] `composer lint` clean (Pint)
- [x] Targeted suite green (pre-existing failures unrelated: missing `intervention/image` dep, DB-dependent tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health endpoint `/` response structure now includes `status`, `service`, and `git_tag` fields.
  * Removed legacy `message` and `app_url` fields from responses.
  * Debug field conditionally present only when `app.debug` is enabled.
  * Service field combines application name and environment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->