### PR TITLE
feat: support Laravel 12, drop EOL Laravel 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,22 +15,22 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ['8.3', '8.4']
-        laravel-version: ['10.*', '11.*']
+        laravel-version: ['11.*', '12.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel-version: '10.*'
-            testbench-version: '8.*'
           - laravel-version: '11.*'
             testbench-version: '9.*'
+          - laravel-version: '12.*'
+            testbench-version: '10.*'
         exclude:
-          # Floor versions of Laravel 10 (10.15) and Laravel 11 (11.0) both
-          # pull in Symfony 6.x / 7.0, which predate PHP 8.4 and emit
-          # "implicit-nullable param" deprecations that Laravel's bootstrap
-          # converts to fatals before the test runner starts. Skip the
-          # prefer-lowest legs on PHP 8.4 — floor coverage is still exercised
-          # on PHP 8.3 (matches the package's `php: ^8.3` requirement), and
-          # PHP 8.4 still gets prefer-stable coverage on both Laravel legs.
+          # Laravel 11's floor (11.0) pulls in Symfony 7.0, which predates PHP
+          # 8.4 and emits "implicit-nullable param" deprecations that Laravel's
+          # bootstrap converts to fatals before the test runner starts. Skip
+          # only that leg. Laravel 12's floor pulls Symfony 7.2 (8.4-clean), so
+          # it keeps prefer-lowest coverage on PHP 8.4. Both lines keep PHP 8.3
+          # floor coverage and PHP 8.4 prefer-stable coverage.
           - php-version: '8.4'
+            laravel-version: '11.*'
             dependency-version: prefer-lowest
 
     name: PHP ${{ matrix.php-version }} - Laravel ${{ matrix.laravel-version }} (${{ matrix.dependency-version }})

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version](https://img.shields.io/packagist/v/nuimarkets/laravel-shared-utils.svg?style=flat-square)](https://packagist.org/packages/nuimarkets/laravel-shared-utils)
 [![PHP Version](https://img.shields.io/packagist/php-v/nuimarkets/laravel-shared-utils.svg?style=flat-square)](https://packagist.org/packages/nuimarkets/laravel-shared-utils)
-[![Laravel Version](https://img.shields.io/badge/laravel-10.x%20|%2011.x-brightgreen.svg?style=flat-square)](https://laravel.com)
+[![Laravel Version](https://img.shields.io/badge/laravel-11.x%20|%2012.x-brightgreen.svg?style=flat-square)](https://laravel.com)
 [![Tests](https://img.shields.io/github/actions/workflow/status/nuimarkets/nui-laravel-shared-utils/tests.yml?branch=master&label=tests&style=flat-square)](https://github.com/nuimarkets/nui-laravel-shared-utils/actions)
 [![License](https://img.shields.io/packagist/l/nuimarkets/laravel-shared-utils.svg?style=flat-square)](https://packagist.org/packages/nuimarkets/laravel-shared-utils)
 
@@ -84,7 +84,7 @@ Automated test database management, specialized test jobs for queue testing, JSO
 ## Requirements
 
 - PHP 8.3 or higher
-- Laravel 10.15+ or 11.x
+- Laravel 11.x or 12.x
 - Composer 2.x
 
 ## Installation
@@ -311,29 +311,30 @@ The package intentionally doesn't auto-register a service provider, giving you f
 
 ### Picking a release line
 
-This package ships two parallel lines, selected via your `composer.json` constraint:
+This package ships multiple release lines, selected via your `composer.json` constraint:
 
 | Constraint | Laravel | PHP    | PHPUnit | Status                                |
 |------------|---------|--------|---------|---------------------------------------|
-| `^0.6.x`   | 10.15+ / 11.x | 8.3+ | 10.5+ | **Actively developed.** All new work lands here. |
+| `^0.7.x`   | 11.x / 12.x   | 8.3+ | 10.5+ | **Actively developed.** All new work lands here. |
+| `^0.6.x`   | 10.15+ / 11.x | 8.3+ | 10.5+ | Maintenance pin for Laravel 10 consumers. No new features. |
 | `^0.5.x`   | 8.x / 9.x     | 8.0+ | 9.x   | Maintenance pin for legacy consumers. No new features. |
 
-Caret constraints (`^0.5.0` etc.) protect you from accidental cross-line upgrades — `composer update` will not pull `0.6.x` over a `^0.5.x` pin. To move to the new line, change the constraint explicitly:
+Caret constraints (`^0.5.0` etc.) protect you from accidental cross-line upgrades: `composer update` will not pull `0.7.x` over a `^0.6.x` pin. To move to the new line, change the constraint explicitly:
 
 ```bash
-composer require nuimarkets/laravel-shared-utils:^0.6
+composer require nuimarkets/laravel-shared-utils:^0.7
 ```
 
-If you do this on a host that's still running Laravel 9 or PHPUnit 9, Composer will refuse the install (the `0.6.x` line declares `conflict` against PHPUnit `<10.5`, and Laravel 9 transitively requires Monolog 2 which conflicts with our `monolog: ^3.0` requirement). Upgrade Laravel + PHPUnit in the same PR as the bump — see *Upgrading consumers to PHPUnit 10+* below for the specific changes required.
+If you do this on a host still running Laravel 10 or older (or PHPUnit 9), Composer will refuse the install: the `0.7.x` line requires `laravel/framework: ^11.0|^12.0` and declares `conflict` against PHPUnit `<10.5`. (Laravel 9 also transitively requires Monolog 2, which conflicts with our `monolog: ^3.0` requirement.) Upgrade Laravel + PHPUnit in the same PR as the bump. See *Upgrading consumers to PHPUnit 10+* below for the specific changes required.
 
 ### Cross-Version Compatibility
 
 | Laravel | PHP | Monolog | Orchestra Testbench |
 |---------|-----|---------|---------------------|
-| 10.15+ | 8.3+ | 3.x | 8.x |
 | 11.x   | 8.3+ | 3.x | 9.x |
+| 12.x   | 8.3+ | 3.x | 10.x |
 
-> `laravel/framework` floor is `^10.15` because `Illuminate\Console\Scheduling\ScheduleRunCommand::handle()` gained its `Cache $cache` parameter in 10.15.0. Earlier 10.x releases would fatal at class-load because our override declares the 4-arg signature.
+> `laravel/framework` floor is `^11.0`. Laravel 10 reached end-of-life (security support ended February 2025) and was dropped in 0.7.0. The `ScheduleRunCommand::handle()` override declares a 4-arg signature (`Schedule, Dispatcher, Cache, ExceptionHandler`) that matches both the Laravel 11 and Laravel 12 parent, so the class loads cleanly on either line.
 
 #### Laravel 11 exception handler wiring
 
@@ -356,7 +357,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
 #### Upgrading consumers to PHPUnit 10+ (Laravel 11)
 
-> **This is not optional under `^0.6.x`.** `DBSetupExtension` now declares `implements PHPUnit\Runner\Extension\Extension`. PHP resolves that interface at autoload, so any consumer code that does `new DBSetupExtension(...)` directly — for example a `tests/Utils/TestCase.php` that calls `->runTestingMigrations()` / `->runTestingSeeder(...)` outside the phpunit.xml extension lifecycle — will fatal on a PHPUnit 9 host the first time it loads the class:
+> **This is not optional under `^0.7.x`.** `DBSetupExtension` now declares `implements PHPUnit\Runner\Extension\Extension`. PHP resolves that interface at autoload, so any consumer code that does `new DBSetupExtension(...)` directly — for example a `tests/Utils/TestCase.php` that calls `->runTestingMigrations()` / `->runTestingSeeder(...)` outside the phpunit.xml extension lifecycle — will fatal on a PHPUnit 9 host the first time it loads the class:
 >
 > ```
 > Error: Interface "PHPUnit\Runner\Extension\Extension" not found

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "^8.3",
     "ext-gd": "*",
     "monolog/monolog": "^3.0",
-    "laravel/framework": "^10.15|^11.0",
+    "laravel/framework": "^11.0|^12.0",
     "sentry/sentry-laravel": "^4.11",
     "guzzlehttp/guzzle": "^7.0",
     "swisnl/json-api-client": "^2.2",
@@ -31,8 +31,8 @@
     "test-coverage": "phpunit --coverage-html coverage"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.5|^11.0",
-    "orchestra/testbench": "^8.0|^9.0",
+    "phpunit/phpunit": "^10.5|^11.0|^12.0",
+    "orchestra/testbench": "^9.0|^10.0",
     "laravel/pint": "^1.0",
     "mockery/mockery": "^1.6"
   },
@@ -55,7 +55,7 @@
     },
     "audit": {
       "ignore": {
-        "CVE-2026-48019": "CRLF injection in Laravel's default email rule. No 10.x/11.x backport exists yet (fixed only in 12.60+/13.10+), so it blocks all installs in our ^10.15|^11.0 range. Remove once an 11.x patch ships."
+        "CVE-2026-48019": "CRLF injection in Laravel's default email rule. Fixed in 12.60+/13.10+; the upstream advisory (GHSA-5vg9-5847-vvmq) lists affected ranges as 12.x below 12.60 and 13.x up to 13.9 and does not list Laravel 11. Composer's advisory DB still flags our Laravel 11 floor, so `composer audit` reports it on both the L11 and the L12-below-12.60 legs; no 11.x patch is expected. Remove once resolved versions clear the advisory (L12 floored at 12.60+ and the L11 line dropped)."
       }
     }
   }

--- a/docs/RemoteRepository.md
+++ b/docs/RemoteRepository.md
@@ -68,7 +68,7 @@ Required dependencies are automatically installed:
 
 - `php: ^8.3`
 - `swisnl/json-api-client: ^2.2`
-- `laravel/framework: ^10.15|^11.0`
+- `laravel/framework: ^11.0|^12.0`
 
 ## Basic Usage
 

--- a/tests/Feature/Exceptions/BaseErrorHandlerTest.php
+++ b/tests/Feature/Exceptions/BaseErrorHandlerTest.php
@@ -10,6 +10,7 @@ use Illuminate\Validation\ValidationException;
 use NuiMarkets\LaravelSharedUtils\Exceptions\BaseErrorHandler;
 use NuiMarkets\LaravelSharedUtils\Exceptions\RemoteServiceException;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class BaseErrorHandlerTest extends TestCase
@@ -390,9 +391,7 @@ class BaseErrorHandlerTest extends TestCase
         $this->assertEquals('Invalid UUID format.', $data['errors'][0]['detail']);
     }
 
-    /**
-     * @dataProvider invalidStatusCodeProvider
-     */
+    #[DataProvider('invalidStatusCodeProvider')]
     public function test_invalid_status_codes_normalize_to_500(int $invalidCode): void
     {
         Log::shouldReceive('warning')
@@ -457,9 +456,7 @@ class BaseErrorHandlerTest extends TestCase
         $this->assertEquals('Internal Server Error', $data['meta']['message']);
     }
 
-    /**
-     * @dataProvider validStatusCodeProvider
-     */
+    #[DataProvider('validStatusCodeProvider')]
     public function test_valid_status_codes_pass_through_unchanged(int $validCode, string $expectedTitle): void
     {
         // Valid codes should NOT trigger warning log

--- a/tests/Feature/FrankenPhpHealthCheckTest.php
+++ b/tests/Feature/FrankenPhpHealthCheckTest.php
@@ -4,6 +4,7 @@ namespace NuiMarkets\LaravelSharedUtils\Tests\Feature;
 
 use NuiMarkets\LaravelSharedUtils\Http\Controllers\HealthCheckController;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class FrankenPhpHealthCheckTest extends TestCase
 {
@@ -15,7 +16,7 @@ class FrankenPhpHealthCheckTest extends TestCase
         config(['app.env' => 'local']);
     }
 
-    /** @test */
+    #[Test]
     public function test_php_environment_includes_frankenphp_info_when_running_under_frankenphp()
     {
         // Mock php_sapi_name to return 'frankenphp'
@@ -75,7 +76,7 @@ class FrankenPhpHealthCheckTest extends TestCase
         $this->assertContains('frankenphp_request_headers', $data['checks']['php']['frankenphp']['available_functions']);
     }
 
-    /** @test */
+    #[Test]
     public function test_php_environment_does_not_include_frankenphp_info_when_not_running_under_frankenphp()
     {
         $controller = new class extends HealthCheckController

--- a/tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php
+++ b/tests/Feature/Http/Controllers/ApplicationCacheControllerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Redis;
 use NuiMarkets\LaravelSharedUtils\Http\Controllers\ApplicationCacheController;
 use NuiMarkets\LaravelSharedUtils\Http\Controllers\ClearLadaAndResponseCacheController;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Tests for ApplicationCacheController + the ?include=app delegation
@@ -87,7 +88,7 @@ class ApplicationCacheControllerTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function forget_removes_a_known_key()
     {
         Cache::put('lookup:countries:all', ['NZ', 'AU'], 600);
@@ -103,7 +104,7 @@ class ApplicationCacheControllerTest extends TestCase
         $this->assertFalse(Cache::has('lookup:countries:all'));
     }
 
-    /** @test */
+    #[Test]
     public function forget_reports_existed_before_false_when_key_missing()
     {
         $response = $this->get('/forget?key=cache:absent:all&token='.self::VALID_TOKEN);
@@ -115,7 +116,7 @@ class ApplicationCacheControllerTest extends TestCase
         $response->assertJsonPath('message', 'Application cache key was already absent');
     }
 
-    /** @test */
+    #[Test]
     public function forget_returns_422_when_key_missing()
     {
         $response = $this->get('/forget?token='.self::VALID_TOKEN);
@@ -127,7 +128,7 @@ class ApplicationCacheControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function forget_returns_422_when_key_blank()
     {
         $response = $this->get('/forget?key=&token='.self::VALID_TOKEN);
@@ -135,7 +136,7 @@ class ApplicationCacheControllerTest extends TestCase
         $response->assertStatus(422);
     }
 
-    /** @test */
+    #[Test]
     public function forget_returns_401_without_token()
     {
         $response = $this->get('/forget?key=anything');
@@ -147,7 +148,7 @@ class ApplicationCacheControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function forget_returns_401_with_wrong_token()
     {
         $response = $this->get('/forget?key=anything&token=not-the-real-token');
@@ -155,7 +156,7 @@ class ApplicationCacheControllerTest extends TestCase
         $response->assertStatus(401);
     }
 
-    /** @test */
+    #[Test]
     public function forget_returns_401_when_clear_cache_token_unconfigured()
     {
         // Wipe the configured token: even a request carrying any token must fail.
@@ -166,7 +167,7 @@ class ApplicationCacheControllerTest extends TestCase
         $response->assertStatus(401);
     }
 
-    /** @test */
+    #[Test]
     public function clear_cache_with_include_app_flushes_application_cache()
     {
         $this->skipIfNoRedis();
@@ -184,7 +185,7 @@ class ApplicationCacheControllerTest extends TestCase
         $this->assertFalse(Cache::has('lookup:currencies:all'));
     }
 
-    /** @test */
+    #[Test]
     public function clear_cache_without_include_app_does_not_flush_application_cache()
     {
         $this->skipIfNoRedis();
@@ -205,7 +206,7 @@ class ApplicationCacheControllerTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function clear_cache_with_include_app_returns_401_without_token()
     {
         // No skipIfNoRedis() here: the auth gate returns 401 before

--- a/tests/Feature/Http/Controllers/ClearLadaAndResponseCacheControllerTest.php
+++ b/tests/Feature/Http/Controllers/ClearLadaAndResponseCacheControllerTest.php
@@ -5,6 +5,7 @@ namespace NuiMarkets\LaravelSharedUtils\Tests\Feature\Http\Controllers;
 use Illuminate\Support\Facades\Redis;
 use NuiMarkets\LaravelSharedUtils\Http\Controllers\ClearLadaAndResponseCacheController;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Tests for ClearLadaAndResponseCacheController.
@@ -76,7 +77,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_correct_response_structure()
     {
         $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
@@ -103,7 +104,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_zeros_when_no_cache_libraries_installed()
     {
         // Without Lada/ResponseCache installed, should return 0s
@@ -119,7 +120,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         $this->assertEquals(0, $data['tag_keys']['before']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_correct_redis_prefix_in_response()
     {
         $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
@@ -128,7 +129,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         $this->assertEquals('test_prefix_', $response->json('detail.prefix'));
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_duration_in_response()
     {
         $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
@@ -138,7 +139,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         $this->assertGreaterThanOrEqual(0, $response->json('detail.duration_ms'));
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_correct_message_when_cache_not_available()
     {
         $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
@@ -150,7 +151,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_restricts_access_without_token()
     {
         $response = $this->get('/clear-cache');
@@ -162,7 +163,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_denies_access_with_invalid_token()
     {
         $response = $this->get('/clear-cache?token=wrong_token');
@@ -170,7 +171,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         $response->assertStatus(401);
     }
 
-    /** @test */
+    #[Test]
     public function it_denies_access_when_clear_cache_token_unconfigured()
     {
         // Wipe the configured token: even a request carrying any token must fail.
@@ -181,7 +182,7 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
         $response->assertStatus(401);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_response_cache_status()
     {
         $response = $this->get('/clear-cache?token='.self::VALID_TOKEN);
@@ -199,9 +200,8 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
      * installed in this package's test suite, so we invoke the private helper to
      * verify cursor/prefix handling, query-vs-tag classification, count-only vs
      * delete modes, and that unrelated keys survive.
-     *
-     * @test
      */
+    #[Test]
     public function it_scans_and_clears_only_lada_keys()
     {
         $connection = Redis::connection('default');
@@ -248,9 +248,8 @@ class ClearLadaAndResponseCacheControllerTest extends TestCase
      * Seeds more than SCAN_COUNT (1000) keys so the sweep spans multiple cursor
      * iterations and triggers the mid-loop UNLINK batch flush, not just the
      * trailing remainder. Guards the batching boundary the small test misses.
-     *
-     * @test
      */
+    #[Test]
     public function it_clears_lada_keys_across_multiple_scan_batches()
     {
         $connection = Redis::connection('default');

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -4,6 +4,7 @@ namespace NuiMarkets\LaravelSharedUtils\Tests\Feature\Http\Controllers;
 
 use NuiMarkets\LaravelSharedUtils\Http\Controllers\HomeController;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Tests for the basic health endpoint (GET /) response shape.
@@ -33,7 +34,7 @@ class HomeControllerTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_the_standardized_health_payload()
     {
         putenv('GIT_TAG=v6.8.0');
@@ -49,7 +50,7 @@ class HomeControllerTest extends TestCase
         $response->assertJsonPath('git_tag', 'v6.8.0');
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_null_git_tag_when_unset()
     {
         // Explicitly clear so the test is deterministic regardless of test
@@ -67,7 +68,7 @@ class HomeControllerTest extends TestCase
         $response->assertJsonPath('git_tag', null);
     }
 
-    /** @test */
+    #[Test]
     public function it_omits_debug_when_app_debug_is_false()
     {
         config()->set('app.debug', false);
@@ -78,7 +79,7 @@ class HomeControllerTest extends TestCase
         $this->assertArrayNotHasKey('debug', $response->json());
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_debug_when_app_debug_is_true()
     {
         config()->set('app.debug', true);
@@ -89,7 +90,7 @@ class HomeControllerTest extends TestCase
         $response->assertJsonPath('debug', true);
     }
 
-    /** @test */
+    #[Test]
     public function it_does_not_leak_the_old_response_shape()
     {
         config()->set('app.debug', true);

--- a/tests/Unit/Logging/ColoredJsonLineFormatterTest.php
+++ b/tests/Unit/Logging/ColoredJsonLineFormatterTest.php
@@ -5,6 +5,7 @@ namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Logging;
 use NuiMarkets\LaravelSharedUtils\Logging\ColoredJsonLineFormatter;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 use NuiMarkets\LaravelSharedUtils\Tests\Utils\LoggingTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class ColoredJsonLineFormatterTest extends TestCase
 {
@@ -18,7 +19,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->formatter = new ColoredJsonLineFormatter;
     }
 
-    /** @test */
+    #[Test]
     public function test_formats_log_record_correctly()
     {
         $record = $this->createMonolog3Record(
@@ -35,7 +36,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->assertStringContainsString('value', $output);
     }
 
-    /** @test */
+    #[Test]
     public function test_handles_empty_context_gracefully()
     {
         $record = $this->createMonolog3Record();
@@ -48,7 +49,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->assertStringNotContainsString('key', $output);
     }
 
-    /** @test */
+    #[Test]
     public function test_extracts_class_name_from_source_file()
     {
         $record = $this->createMonolog3Record(
@@ -62,7 +63,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->assertStringNotContainsString('UserServiceTrait', $output);
     }
 
-    /** @test */
+    #[Test]
     public function test_handles_missing_source_file()
     {
         $record = $this->createMonolog3Record();
@@ -74,7 +75,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->assertIsString($output);
     }
 
-    /** @test */
+    #[Test]
     public function test_formats_nested_context_data()
     {
         $record = $this->createMonolog3Record(
@@ -100,7 +101,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->assertStringContainsString('192.168.1.1', $output);
     }
 
-    /** @test */
+    #[Test]
     public function test_handles_different_log_levels()
     {
         $levels = [
@@ -120,7 +121,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function test_removes_trait_interface_abstract_from_class_names()
     {
         $testCases = [
@@ -140,7 +141,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function test_exception_shows_object_name_by_default()
     {
         $exception = new \RuntimeException('Something broke');
@@ -156,7 +157,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->assertStringNotContainsString('Something broke', $output);
     }
 
-    /** @test */
+    #[Test]
     public function test_exception_expanded_when_config_enabled()
     {
         config()->set('logging-utils.error_logging.expand_exceptions', true);
@@ -175,7 +176,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->assertStringNotContainsString('Object(', $output);
     }
 
-    /** @test */
+    #[Test]
     public function test_expanded_exception_includes_previous()
     {
         config()->set('logging-utils.error_logging.expand_exceptions', true);
@@ -195,7 +196,7 @@ class ColoredJsonLineFormatterTest extends TestCase
         $this->assertStringContainsString('InvalidArgumentException', $output);
     }
 
-    /** @test */
+    #[Test]
     public function test_output_contains_newline_termination()
     {
         $record = $this->createMonolog3Record();

--- a/tests/Unit/RemoteRepositories/FailureCategoryTest.php
+++ b/tests/Unit/RemoteRepositories/FailureCategoryTest.php
@@ -4,6 +4,7 @@ namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\RemoteRepositories;
 
 use NuiMarkets\LaravelSharedUtils\RemoteRepositories\FailureCategory;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FailureCategoryTest extends TestCase
 {
@@ -35,9 +36,7 @@ class FailureCategoryTest extends TestCase
         $this->assertNotContains(FailureCategory::UNKNOWN, FailureCategory::TRANSIENT_CATEGORIES);
     }
 
-    /**
-     * @dataProvider transientCategoriesProvider
-     */
+    #[DataProvider('transientCategoriesProvider')]
     public function test_is_transient_returns_true_for_transient_categories(string $category): void
     {
         $this->assertTrue(FailureCategory::isTransient($category));
@@ -53,9 +52,7 @@ class FailureCategoryTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider nonTransientCategoriesProvider
-     */
+    #[DataProvider('nonTransientCategoriesProvider')]
     public function test_is_transient_returns_false_for_non_transient_categories(string $category): void
     {
         $this->assertFalse(FailureCategory::isTransient($category));

--- a/tests/Unit/Testing/DBSetupExtensionTest.php
+++ b/tests/Unit/Testing/DBSetupExtensionTest.php
@@ -7,6 +7,7 @@ use Mockery;
 use NuiMarkets\LaravelSharedUtils\Testing\DBSetupExtension;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 use PHPUnit\Event\TestRunner\StartedSubscriber;
+use PHPUnit\Framework\Attributes\Test;
 
 class DBSetupExtensionTest extends TestCase
 {
@@ -24,7 +25,7 @@ class DBSetupExtensionTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_exposes_a_started_subscriber_for_registration(): void
     {
         $subscriber = (new DBSetupExtension)->createTestRunnerStartedSubscriber();
@@ -32,7 +33,7 @@ class DBSetupExtensionTest extends TestCase
         $this->assertInstanceOf(StartedSubscriber::class, $subscriber);
     }
 
-    /** @test */
+    #[Test]
     public function its_subscriber_routes_notify_to_execute_before_first_test(): void
     {
         // Concrete extension whose executeBeforeFirstTest() flips a flag — lets us
@@ -63,7 +64,7 @@ class DBSetupExtensionTest extends TestCase
         $this->assertTrue($extension->invoked);
     }
 
-    /** @test */
+    #[Test]
     public function it_skips_execution_when_db_setup_env_not_set(): void
     {
         // Ensure DB_SETUP is not set
@@ -78,7 +79,7 @@ class DBSetupExtensionTest extends TestCase
         $this->assertTrue(true);
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_temporary_connection_without_database(): void
     {
         // Setup: Configure a test database connection
@@ -124,7 +125,7 @@ class DBSetupExtensionTest extends TestCase
         $this->assertEquals('127.0.0.1', $tempConnection['host']);
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_config_directly_on_container_not_facade(): void
     {
         // Setup: Configure a test database connection
@@ -167,7 +168,7 @@ class DBSetupExtensionTest extends TestCase
         $this->assertEquals('pgsql', $containerConfig['driver']);
     }
 
-    /** @test */
+    #[Test]
     public function it_preserves_original_connection_config(): void
     {
         // Setup: Configure a test database connection
@@ -215,7 +216,7 @@ class DBSetupExtensionTest extends TestCase
         $this->assertNull($tempConfig['database'], 'Temp connection database should be null');
     }
 
-    /** @test */
+    #[Test]
     public function it_makes_temp_connection_resolvable_by_database_manager(): void
     {
         // Setup


### PR DESCRIPTION
## Summary
- Widen `laravel/framework` to `^11.0|^12.0` so consuming services can move to Laravel 12. Drop Laravel 10 (EOL since Feb 2025, no longer used).
- Bump the dev/test matrix: `orchestra/testbench` `^9.0|^10.0`, add `phpunit/phpunit` `^12.0`. CI now runs the suite on Laravel 11 and 12 across prefer-lowest and prefer-stable.
- Migrate test metadata from doc-comment annotations (`@test`, `@dataProvider`) to PHP 8 attributes (`#[Test]`, `#[DataProvider]`). PHPUnit 12 (pulled in by testbench 10) no longer honors doc-comment metadata, which otherwise dropped 28 tests and broke 4 data-provider cases.
- Update README compatibility tables and RemoteRepository docs for the 11.x/12.x line.

## Review
Internal: 5 auto-fixed (CI exclusion scoping, doc accuracy). External (Codex + Kimi, parallel): converged on one finding (stale Laravel version badge), fixed. No correctness or resolvability issues; no behavioral change.

## Changes
11 files, +78 / -80. composer.json constraints, CI matrix, README/docs, and 7 test files migrated to PHPUnit attributes.

## Test plan
- [x] Suite green on all four legs: Laravel 11/12 x prefer-lowest/prefer-stable (577 tests)
- [x] `ScheduleRunCommand::handle()` override matches the Laravel 12 parent signature (no class-load fatal)
- [x] CVE audit-ignore verified on the Laravel 12 floor leg (12.1 < 12.60)
- [x] `#[Test]`/`#[DataProvider]` attributes confirmed working on the PHPUnit 10.5 floor (Laravel 11 prefer-lowest)
- [ ] CI matrix green on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Laravel 12 and PHPUnit 12.
  * Updated minimum Laravel requirement from 10.15 to 11.0.

* **Documentation**
  * Updated compatibility documentation for Laravel 11/12 support.
  * Added PHPUnit 10+ setup guidance.

* **Chores**
  * Updated test infrastructure and CI/CD pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->