### PR TITLE
fix(intercom): set last_request_at at top level, not in custom_attributes

### DIFF
--- a/src/Services/IntercomService.php
+++ b/src/Services/IntercomService.php
@@ -151,8 +151,12 @@ class IntercomService
         try {
             $userData = [
                 'external_id' => $userId,
+                // last_request_at is a standard Intercom contact field. It must be set at the
+                // top level; Intercom rejects the whole POST /contacts payload with
+                // parameter_invalid ("'last_request_at' is one of our standard attributes") if
+                // it is nested under custom_attributes.
+                'last_request_at' => time(),
                 'custom_attributes' => array_merge($attributes, [
-                    'last_request_at' => time(),
                     'service_last_active' => $this->serviceName,
                 ]),
             ];

--- a/tests/Unit/Services/IntercomServiceTest.php
+++ b/tests/Unit/Services/IntercomServiceTest.php
@@ -186,6 +186,9 @@ class IntercomServiceTest extends TestCase
                    $data['external_id'] === 'user-123' &&
                    $data['email'] === 'test@example.com' &&
                    $data['name'] === 'Test User' &&
+                   // last_request_at is a reserved standard field: top level, never custom_attributes.
+                   is_int($data['last_request_at']) &&
+                   ! isset($data['custom_attributes']['last_request_at']) &&
                    $data['custom_attributes']['custom_field'] === 'custom_value' &&
                    $data['custom_attributes']['service_last_active'] === 'connect-service-test';
         });


### PR DESCRIPTION
## Summary
- `IntercomService::createOrUpdateUser()` nested `last_request_at` inside `custom_attributes`. It is a **reserved standard Intercom contact field**, so Intercom rejects the entire `POST /contacts` payload with `parameter_invalid` ("'last_request_at' is one of our standard attributes for your people data. To save this as new people data, use a different name.").
- Effect: every contact upsert through this method failed for **every workspace and every consumer**, and silently wrote nothing because callers log-and-swallow the error. Found while verifying connect-auth's nuiConnect upsert on dev (CON-2179): the `POST /contacts` failed on `last_request_at` even after the custom attributes existed.
- Fix: promote `last_request_at` to the top level of the payload (where Intercom accepts it). `service_last_active` stays a genuine custom attribute.

## Backwards compatibility
- No method signature change. `createOrUpdateUser(string $userId, array $attributes = [])` is unchanged.
- Only the outgoing Intercom payload shape changes (`last_request_at` moves from `custom_attributes` to top level). The previous shape always failed at Intercom, so this is strictly a fix: consumers get a working upsert after upgrading, with no code changes required on their side.

## Test plan
- [x] `IntercomServiceTest` green (47 tests); `test_create_or_update_user_success` now asserts `last_request_at` is a top-level int and absent from `custom_attributes`
- [x] Verified live: direct `POST /contacts` with top-level `last_request_at` accepted by a real Intercom workspace
- [x] Pint clean on changed files
- [ ] Consumer bump: connect-auth must require the released version for its nuiConnect upsert (CON-2179) to work end to end


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user synchronization with Intercom by correcting the structure of contact data payloads. The `last_request_at` timestamp is now properly positioned as a standard contact attribute rather than a custom field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->