### PR TITLE
fix(remote-repository): replace removed encode() in request logging

### DIFF
--- a/src/RemoteRepositories/RemoteRepository.php
+++ b/src/RemoteRepositories/RemoteRepository.php
@@ -467,7 +467,7 @@ abstract class RemoteRepository
                 if (config('app.remote_repository.log_requests', false)) {
                     Log::info('Request Debug', [
                         'url' => $url,
-                        'body' => $this->client->encode($data),
+                        'body' => $data->toArray(),
                         'headers' => $this->headers,
                     ]);
                     Log::debug('API POST', ['url' => $url]);

--- a/tests/Unit/RemoteRepositories/RemoteRepositoryRequestLoggingTest.php
+++ b/tests/Unit/RemoteRepositories/RemoteRepositoryRequestLoggingTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\RemoteRepositories;
+
+use Illuminate\Support\Facades\Log;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use NuiMarkets\LaravelSharedUtils\Tests\Utils\RemoteRepositoryTestHelpers;
+use Swis\JsonApi\Client\Interfaces\ItemDocumentInterface;
+
+/**
+ * Guards the request-logging branch of RemoteRepository::post().
+ *
+ * The branch is only reached when remote_repository.log_requests is enabled,
+ * so the rest of the suite (which runs with it off) never exercised it. That
+ * gap let a removed json-api-client method survive a major-version bump: the
+ * v1 client exposed encode(), v2 dropped it, and the branch kept calling it,
+ * turning every logged POST into a fatal error. The regression is about the
+ * client surface, so the document is a plain ItemDocumentInterface double:
+ * post() must serialise the body via the document's own toArray() and never
+ * reach for a method that the v2 client no longer has.
+ */
+class RemoteRepositoryRequestLoggingTest extends TestCase
+{
+    use RemoteRepositoryTestHelpers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRemoteRepositoryConfig();
+        config(['app.remote_repository.log_requests' => true]);
+    }
+
+    private function makeDocument(array $body = ['test' => 'data']): ItemDocumentInterface
+    {
+        $document = $this->createMock(ItemDocumentInterface::class);
+        $document->method('toArray')->willReturn($body);
+
+        return $document;
+    }
+
+    public function test_post_logs_request_body_via_document_not_a_removed_client_method()
+    {
+        $mockClient = $this->createMockClient();
+        $mockClient->expects($this->once())
+            ->method('post')
+            ->willReturn($this->createSuccessResponse());
+
+        // The client double only implements the v2 DocumentClientInterface
+        // surface (get/post/patch/delete/get|setBaseUri). If post() reaches for
+        // a client method that no longer exists (v1's encode()), the mock raises
+        // and this test fails.
+        $repository = $this->createTestRepositoryWithPublicMethods($mockClient);
+
+        Log::spy();
+
+        $repository->publicPost('/test', $this->makeDocument(['k' => 'v']));
+
+        // The logged body is exactly what the document serialised itself to,
+        // proving the branch went through $data->toArray() rather than the
+        // removed client encode().
+        Log::shouldHaveReceived('info')
+            ->once()
+            ->withArgs(function ($message, $context) {
+                return $message === 'Request Debug'
+                    && ($context['body'] ?? null) === ['k' => 'v'];
+            });
+    }
+
+    public function test_logging_branch_does_not_alter_the_outbound_request()
+    {
+        $captured = null;
+        $mockClient = $this->createMockClient();
+        $mockClient->expects($this->once())
+            ->method('post')
+            ->willReturnCallback(function ($url, $document, $headers) use (&$captured) {
+                $captured = [$url, $document];
+
+                return $this->createSuccessResponse();
+            });
+
+        $repository = $this->createTestRepositoryWithPublicMethods($mockClient);
+        $document = $this->makeDocument();
+
+        Log::spy();
+
+        $repository->publicPost('/test', $document);
+
+        // The original document instance is forwarded to the client untouched by
+        // the log serialisation.
+        $this->assertSame('/test', $captured[0]);
+        $this->assertSame($document, $captured[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- The request-logging branch in `RemoteRepository::post()` called `DocumentClient::encode()`, which json-api-client v2 removed. Any POST made with request logging enabled threw `Error: Call to undefined method DocumentClient::encode()` and surfaced as an HTTP 500.
- Serialise the document with `$data->toArray()` instead (declared on `DocumentInterface`, present in v2). An array body also lets the sensitive-data log processor redact PII that an encoded string bypassed.
- Log-only change: the outbound request still serialises the body via the client's `post()`, so the wire request is unchanged.
- Add a regression test covering the `log_requests=true` POST branch against a v2 client double; the existing suite ran with request logging off, so this path was never exercised.

## Review
Internal review: clean. External review (Codex + Kimi agentic): clean, no findings. All three independently confirmed `toArray()` is type-valid on the interface, the change is log-only, and the new test fails against the removed `encode()` call (non-tautological).

## Changes
```
 src/RemoteRepositories/RemoteRepository.php        |  2 +-
 .../RemoteRepositoryRequestLoggingTest.php         | 93 ++++++++++++++++++++++
 2 files changed, 94 insertions(+), 1 deletion(-)
```

## Test plan
- [x] New `RemoteRepositoryRequestLoggingTest` (2 tests) - verified red against `encode()`, green with `toArray()`
- [x] Full RemoteRepository suite green (82 tests, 204 assertions)
- [x] Pint clean
- [x] Pre-existing suite errors (FailureCategory / BaseErrorHandler / AttachmentServiceResize) confirmed unrelated (also fail on origin/master)