### PR TITLE
feat(attachments): opt-in malware scanning via YARA-X CLI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,14 @@ jobs:
           "orchestra/testbench:${{ matrix.testbench-version }}"
 
     - name: Install dependencies
+      env:
+        # The matrix intentionally pins floor versions (e.g. Laravel 11.0 on
+        # prefer-lowest) that accumulate security advisories; composer 2.9+
+        # blocks advisory-flagged versions at resolve time by default, which
+        # would fail these legs. Scope the bypass to this install step only;
+        # `composer audit` still reports advisories in the log, and local
+        # `composer update`/`require` keep full security blocking.
+        COMPOSER_NO_SECURITY_BLOCKING: "1"
       run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
 
     - name: List Installed Dependencies

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Opt-in write-request idempotency for retry-safe endpoints. Supports
 inflight locks, response replay, and conflict detection when a key is reused
 for different request content.
 
+### **Upload Malware Scanning**
+
+Opt-in YARA-X scanning of every upload processed by AttachmentService, before anything touches S3 or the database. Fail-closed by default, config-gated, and inert until a service ships the scanner binary and enables it.
+
 ### **Failure Caching**
 
 Intelligent caching of remote service failures to prevent cascading timeouts during outages. HTTP status-aware TTLs cache 404s longer than transient errors like timeouts. Includes failure classification, configurable per-category TTLs, and convenience methods for handling cached failures gracefully.
@@ -103,6 +107,7 @@ php artisan vendor:publish --provider="NuiMarkets\LaravelSharedUtils\Providers\L
 php artisan vendor:publish --tag=logging-utils-config
 php artisan vendor:publish --tag=intercom-config
 php artisan vendor:publish --tag=idempotency-config
+php artisan vendor:publish --tag=attachments-config
 ```
 
 ## Documentation
@@ -121,6 +126,7 @@ php artisan vendor:publish --tag=idempotency-config
 | **IncludesParser** | API response optimization utility | [Guide](docs/includes-parser.md) |
 | **IAM RDS Connector** | Short-lived IAM tokens for RDS / RDS Proxy | [Guide](docs/iam-rds-connector.md) |
 | **Machine Token** | Client-credentials token retrieval and caching for service-to-service auth | [Guide](docs/machine-token.md) |
+| **Malware Scanning** | Opt-in YARA-X scan of uploads in AttachmentService | [Guide](docs/malware-scanning.md) |
 
 ### Quick Examples
 
@@ -402,6 +408,14 @@ REMOTE_REPOSITORY_LOG_REQUESTS=true
 INTERCOM_ENABLED=true
 INTERCOM_TOKEN=your_token
 INTERCOM_SERVICE_NAME=my-service
+
+# Attachment Malware Scanning (off by default; needs the yr binary in the image)
+ATTACHMENTS_MALWARE_SCAN_ENABLED=true
+ATTACHMENTS_MALWARE_SCAN_BINARY=yr
+ATTACHMENTS_MALWARE_SCAN_RULES_PATH=/etc/yara/rules.yarc
+ATTACHMENTS_MALWARE_SCAN_COMPILED_RULES=true
+ATTACHMENTS_MALWARE_SCAN_TIMEOUT=10
+ATTACHMENTS_MALWARE_SCAN_FAIL_OPEN=false
 ```
 
 ### RemoteRepository Configuration

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "guzzlehttp/guzzle": "^7.0",
     "swisnl/json-api-client": "^2.2",
     "aws/aws-sdk-php": "^3.342",
-    "intervention/image": "^4.0"
+    "intervention/image": "^4.0",
+    "symfony/process": "^7.0"
   },
   "suggest": {},
   "scripts": {

--- a/config/attachments.php
+++ b/config/attachments.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Malware Scanning
+    |--------------------------------------------------------------------------
+    |
+    | Opt-in malware scanning of uploads processed by AttachmentService. When
+    | enabled, every raw uploaded file is scanned BEFORE any resize or S3
+    | upload; a match rejects the whole request (HTTP 422) and stores nothing.
+    |
+    | Disabled by default: with `enabled` false the scanner is never resolved
+    | and processAttachments() behaves exactly as before this feature existed.
+    | Enabling requires the YARA-X CLI binary and a ruleset to be present in
+    | the runtime image — see docs/malware-scanning.md.
+    |
+    */
+    'malware_scan' => [
+        'enabled' => (bool) env('ATTACHMENTS_MALWARE_SCAN_ENABLED', false),
+
+        // YARA-X CLI binary: bare name resolved via PATH, or an absolute path.
+        'binary' => env('ATTACHMENTS_MALWARE_SCAN_BINARY', 'yr'),
+
+        // A .yar file, a directory of .yar files, or a compiled .yarc bundle
+        // (set compiled_rules=true for the latter). Null uses the baseline
+        // ruleset shipped with this package (EICAR + generic indicators) —
+        // production services should point this at a curated ruleset.
+        // Operator config only: never derive this from request input.
+        'rules_path' => env('ATTACHMENTS_MALWARE_SCAN_RULES_PATH'),
+
+        // Set true when rules_path is a precompiled .yarc bundle (yr compile).
+        'compiled_rules' => (bool) env('ATTACHMENTS_MALWARE_SCAN_COMPILED_RULES', false),
+
+        // Per-file scan timeout; a timeout is a scan failure, not a clean pass.
+        'timeout_seconds' => (int) env('ATTACHMENTS_MALWARE_SCAN_TIMEOUT', 10),
+
+        // DANGEROUS: when true, a scan FAILURE (engine missing/broken/timeout —
+        // not a detection) logs a warning and lets the upload through instead
+        // of rejecting with HTTP 503. Detections always reject regardless.
+        'fail_open' => (bool) env('ATTACHMENTS_MALWARE_SCAN_FAIL_OPEN', false),
+    ],
+];

--- a/docs/malware-scanning.md
+++ b/docs/malware-scanning.md
@@ -1,0 +1,136 @@
+# Malware Scanning
+
+Opt-in malware scanning of uploads processed by `AttachmentService`, backed by the [YARA-X](https://virustotal.github.io/yara-x/) CLI.
+
+When enabled, every raw uploaded file is scanned **before** any image resize and before anything is written to S3 or the database. A match rejects the whole request with HTTP 422 and stores nothing. Scanning is **off by default**: without explicit opt-in, `AttachmentService` behaves exactly as it did before this feature existed and the scanner is never resolved.
+
+## How it works
+
+```text
+processAttachments()
+  └─ scanForMalware()          <- raw bytes, before resize/re-encode
+       ├─ match                -> MalwareDetectedException (HTTP 422), nothing stored
+       ├─ scan failure         -> MalwareScanFailedException (HTTP 503) unless fail_open
+       └─ clean                -> continue to resize (if opted in) and S3 upload
+```
+
+- The scan runs on each file's upload tmp path via a `yr scan` subprocess (process isolation: a scanner crash cannot take the PHP worker down).
+- One rule match on any file rejects the entire request, consistent with the service's all-or-nothing storage semantics.
+- Scan failures (binary missing, unreadable file, engine error, timeout, unparseable output) **fail closed** by default: the upload is rejected with HTTP 503 rather than stored unscanned.
+- For images that consumers resize (avatars/logos), the scan covers the raw original; the stored bytes are the re-encoded JPEG, which strips embedded payloads by construction. Non-images are stored exactly as scanned.
+
+## Requirements
+
+- The YARA-X CLI (`yr`) available in the runtime image. Single static binary; grab it from [YARA-X releases](https://github.com/VirusTotal/yara-x/releases) or build with `cargo install yara-x-cli`.
+- A YARA ruleset (`.yar` source file(s) or a compiled `.yarc` bundle). The package ships a small baseline set (see below).
+
+Behavior is verified against YARA-X 1.19.x. Pin the binary version in your image and re-run the integration test when bumping it.
+
+## Enabling in a service
+
+**1. Ship the `yr` binary** (and optionally a curated ruleset) in the service's runtime image.
+
+**2. Register the provider**, which merges the config (and also loads the package's attachment migrations). The library deliberately has no package auto-discovery, so this is explicit:
+
+```php
+// config/app.php providers, or bootstrap/providers.php on Laravel 11+
+NuiMarkets\LaravelSharedUtils\AttachmentServiceProvider::class,
+```
+
+With the provider registered you can optionally publish the config for local customization (`php artisan vendor:publish --tag=attachments-config`). Alternatively, skip the provider and create `config/attachments.php` yourself; the service reads plain config keys.
+
+**3. Enable via environment:**
+
+```bash
+ATTACHMENTS_MALWARE_SCAN_ENABLED=true
+```
+
+## Configuration
+
+`config/attachments.php`, key `malware_scan`:
+
+| Key | Env | Default | Meaning |
+|-----|-----|---------|---------|
+| `enabled` | `ATTACHMENTS_MALWARE_SCAN_ENABLED` | `false` | Master switch. When false the scanner is never resolved. |
+| `binary` | `ATTACHMENTS_MALWARE_SCAN_BINARY` | `yr` | YARA-X CLI binary: bare name (PATH) or absolute path. |
+| `rules_path` | `ATTACHMENTS_MALWARE_SCAN_RULES_PATH` | `null` | `.yar` file, directory of `.yar` files, or compiled `.yarc`. `null` uses the package baseline ruleset. Operator config only, never derive from request input. |
+| `compiled_rules` | `ATTACHMENTS_MALWARE_SCAN_COMPILED_RULES` | `false` | Set `true` when `rules_path` is a precompiled `.yarc` bundle. |
+| `timeout_seconds` | `ATTACHMENTS_MALWARE_SCAN_TIMEOUT` | `10` | Per-file scan timeout. A timeout is a scan failure, not a clean pass. |
+| `fail_open` | `ATTACHMENTS_MALWARE_SCAN_FAIL_OPEN` | `false` | **Dangerous.** When true, scan *failures* log a warning and let the upload through instead of rejecting with 503. Detections always reject; `fail_open` never bypasses a match. |
+
+## Exceptions
+
+| Exception | HTTP | Meaning |
+|-----------|------|---------|
+| `MalwareDetectedException` | 422 | A rule matched. Client-facing message names the file only; matched rule ids travel in the exception's `extra` (logs/Sentry) so detection logic isn't disclosed to clients. |
+| `MalwareScanFailedException` | 503 | No trustworthy verdict (engine missing/broken/timeout). Retryable once the scanner is healthy. |
+
+Both extend `BaseHttpRequestException`, so services using `BaseErrorHandler` surface them consistently with no extra wiring. Services that catch-and-remap exceptions from `processAttachments()` should pass these two through untouched.
+
+## Rules
+
+### Baseline ruleset
+
+`resources/malware-rules/` ships with the package and is used when `rules_path` is null:
+
+- `eicar.yar`: the [EICAR test string](https://www.eicar.org/download-anti-malware-testfile/), so any deployment can verify the pipeline end-to-end by uploading an EICAR file and expecting a 422.
+- `webshells.yar`: conservative obfuscated-eval webshell indicators.
+
+This baseline **proves the pipeline works; it is not a serious malware guarantee**. Production deployments should point `rules_path` at a curated, maintained ruleset.
+
+### Compiled rules
+
+Compiling at image build time fails fast on bad rules and speeds up each scan:
+
+```dockerfile
+RUN yr compile --output /etc/yara/rules.yarc /etc/yara/rules/
+ENV ATTACHMENTS_MALWARE_SCAN_RULES_PATH=/etc/yara/rules.yarc \
+    ATTACHMENTS_MALWARE_SCAN_COMPILED_RULES=true
+```
+
+## Custom scanner backends
+
+`YaraXScanner` is the default backend. To use something else (e.g. ClamAV), implement the contract and either bind it in the container or inject it:
+
+```php
+use NuiMarkets\LaravelSharedUtils\Contracts\MalwareScanner;
+
+// Container binding — picked up automatically when no scanner is injected
+$this->app->bind(MalwareScanner::class, ClamAvScanner::class);
+
+// Or constructor injection (last parameter)
+new AttachmentService($disk, $model, $pivot, $fk, null, null, $scanner);
+```
+
+Resolution order: constructor injection, then container binding, then `YaraXScanner` built from config. Implementations must throw `MalwareScanFailedException` whenever they cannot produce a trustworthy verdict; returning an empty match list means "definitely clean".
+
+## Testing
+
+`FakeMalwareScanner` (in `src/Testing/`) keeps service tests free of any real binary:
+
+```php
+use NuiMarkets\LaravelSharedUtils\Testing\FakeMalwareScanner;
+
+config()->set('attachments.malware_scan.enabled', true);
+
+$scanner = FakeMalwareScanner::detectingContent('EICAR', ['Eicar_Rule']);
+$service = new AttachmentService($disk, $model, $pivot, $fk, null, null, $scanner);
+
+// FakeMalwareScanner::clean()      — everything passes
+// FakeMalwareScanner::detecting()  — everything matches
+// FakeMalwareScanner::failing()    — every scan throws (engine outage)
+// $scanner->scannedPaths           — records every scanned path
+```
+
+The package's own integration test runs the real binary when available:
+
+```bash
+YARA_X_BINARY=/path/to/yr vendor/bin/phpunit --filter YaraXScannerIntegrationTest
+```
+
+## Operational notes
+
+- **Latency**: one subprocess per uploaded file, typically a few tens of milliseconds with the baseline ruleset. Large rulesets benefit from `.yarc` precompilation.
+- **Resource abuse**: scanning is CPU-bound and per-file. Upload size limits and request rate limiting remain the consuming service's responsibility; `timeout_seconds` bounds each scan.
+- **Monitoring**: every detection logs a warning with the matched rule ids; scan failures log errors (fail closed) or warnings (`fail_open`). Alert on both.
+- **Host AV/EDR**: `resources/malware-rules/eicar.yar` contains the EICAR signature in source form; some endpoint-protection tools quarantine files containing it on checkout. Exclude the vendor path from host scanning, or point `rules_path` at your own ruleset and drop the baseline.

--- a/resources/malware-rules/eicar.yar
+++ b/resources/malware-rules/eicar.yar
@@ -1,0 +1,17 @@
+// EICAR standard anti-malware test file (harmless by design).
+// Reference: https://www.eicar.org/download-anti-malware-testfile/
+// Every deployment can verify its scan pipeline end-to-end by uploading the
+// EICAR test string and expecting a rejection.
+
+rule EICAR_Test_File
+{
+    meta:
+        description = "EICAR standard antivirus test string"
+        reference = "https://www.eicar.org/download-anti-malware-testfile/"
+
+    strings:
+        $eicar = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+
+    condition:
+        $eicar
+}

--- a/resources/malware-rules/webshells.yar
+++ b/resources/malware-rules/webshells.yar
@@ -1,0 +1,25 @@
+// Baseline webshell indicators. Deliberately conservative: these match
+// classic obfuscated-eval dropper patterns that have no place in legitimate
+// document/image uploads, at the cost of missing most real-world malware.
+//
+// This is a SAMPLE ruleset proving the scan pipeline works, not a serious
+// malware guarantee. Production deployments should point
+// attachments.malware_scan.rules_path at a curated, maintained ruleset.
+
+rule PHP_Webshell_Obfuscated_Eval
+{
+    meta:
+        description = "PHP executing an obfuscated (base64/gzip/rot13) payload - classic webshell/dropper pattern"
+
+    strings:
+        $php = "<?php" nocase
+
+        $eval1 = "eval(base64_decode(" nocase
+        $eval2 = "eval(gzinflate(" nocase
+        $eval3 = "eval(gzuncompress(" nocase
+        $eval4 = "eval(str_rot13(" nocase
+        $eval5 = "assert(base64_decode(" nocase
+
+    condition:
+        $php and any of ($eval*)
+}

--- a/src/AttachmentServiceProvider.php
+++ b/src/AttachmentServiceProvider.php
@@ -6,7 +6,7 @@ use Illuminate\Support\ServiceProvider;
 
 /**
  * Service provider for attachment components.
- * Registers migrations for consuming services.
+ * Registers migrations and attachment config for consuming services.
  */
 class AttachmentServiceProvider extends ServiceProvider
 {
@@ -18,11 +18,15 @@ class AttachmentServiceProvider extends ServiceProvider
         // Load migrations from package
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
-        // Publish migrations for customization
+        // Publish migrations and config for customization
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], 'attachments-migrations');
+
+            $this->publishes([
+                __DIR__.'/../config/attachments.php' => config_path('attachments.php'),
+            ], 'attachments-config');
         }
     }
 
@@ -31,6 +35,8 @@ class AttachmentServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        // No services to register
+        // Inert defaults: malware_scan.enabled is false unless the consumer
+        // turns it on, so merging this config changes no behavior by itself.
+        $this->mergeConfigFrom(__DIR__.'/../config/attachments.php', 'attachments');
     }
 }

--- a/src/Contracts/MalwareScanner.php
+++ b/src/Contracts/MalwareScanner.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Contracts;
+
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
+
+/**
+ * Scans a file on local disk for malware.
+ *
+ * Implementations must fail loudly: any condition that prevents a trustworthy
+ * verdict (missing engine, unreadable file, engine error, timeout) throws
+ * MalwareScanFailedException rather than returning an empty match list.
+ */
+interface MalwareScanner
+{
+    /**
+     * Scan the file at $path.
+     *
+     * @return list<string> Identifiers of matched malware rules; an empty list means clean.
+     *
+     * @throws MalwareScanFailedException when no trustworthy verdict could be produced
+     */
+    public function scan(string $path): array;
+}

--- a/src/Exceptions/MalwareDetectedException.php
+++ b/src/Exceptions/MalwareDetectedException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Exceptions;
+
+/**
+ * Thrown when AttachmentService rejects an upload because the malware scan
+ * matched one or more rules. Maps to HTTP 422 via BaseHttpRequestException so
+ * the client sees a clean validation-style rejection. The matched rule ids are
+ * deliberately kept out of the client-facing message (they would disclose
+ * detection logic) and travel in the Sentry/logging extra instead.
+ */
+class MalwareDetectedException extends BaseHttpRequestException
+{
+    /** @var list<string> */
+    protected array $matchedRules;
+
+    /**
+     * @param  string  $filename  Client-supplied original filename (display only)
+     * @param  list<string>  $matchedRules  Identifiers of the matched scan rules
+     */
+    public function __construct(string $filename, array $matchedRules)
+    {
+        $this->matchedRules = $matchedRules;
+
+        parent::__construct(
+            sprintf('Attachment "%s" was rejected by the malware scan.', $filename),
+            422,
+            null,
+            tags: ['malware_scan' => 'detected'],
+            extra: ['file_name' => $filename, 'matched_rules' => $matchedRules],
+        );
+    }
+
+    /** @return list<string> */
+    public function getMatchedRules(): array
+    {
+        return $this->matchedRules;
+    }
+}

--- a/src/Exceptions/MalwareScanFailedException.php
+++ b/src/Exceptions/MalwareScanFailedException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Exceptions;
+
+use Throwable;
+
+/**
+ * Thrown when a malware scan could not produce a trustworthy verdict (missing
+ * binary, unreadable target, engine error, timeout, unparseable output).
+ * Distinct from MalwareDetectedException: this is an operational failure, not
+ * a verdict. Maps to HTTP 503 because the scanner is a required dependency of
+ * the upload path when scanning is enabled and fail_open is off; the client
+ * can retry once the scanner is healthy.
+ *
+ * Keep messages free of local paths and engine output; diagnostic detail
+ * belongs in $extra where it reaches logs/Sentry but not the client.
+ */
+class MalwareScanFailedException extends BaseHttpRequestException
+{
+    public function __construct(string $message, ?Throwable $previous = null, array $extra = [])
+    {
+        parent::__construct(
+            $message,
+            503,
+            $previous,
+            tags: ['malware_scan' => 'failed'],
+            extra: $extra,
+        );
+    }
+}

--- a/src/Services/AttachmentService.php
+++ b/src/Services/AttachmentService.php
@@ -10,6 +10,9 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\ImageManager;
+use NuiMarkets\LaravelSharedUtils\Contracts\MalwareScanner;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareDetectedException;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
 use NuiMarkets\LaravelSharedUtils\Exceptions\ResizeFailedException;
 use Throwable;
 
@@ -75,6 +78,8 @@ class AttachmentService
      */
     protected ?array $imageResizeConfig = null;
 
+    protected ?MalwareScanner $malwareScanner = null;
+
     private ?ImageManager $imageManager = null;
 
     /** @var list<string> */
@@ -87,6 +92,7 @@ class AttachmentService
      * @param  string|null  $foreignKey  - Foreign key name (null for polymorphic)
      * @param  callable|null  $pathBuilder  - Custom path builder: fn(?string $scope): string
      * @param  callable|null  $scopeResolver  - Extract scope identifier from parent entity: fn($entity): ?string
+     * @param  MalwareScanner|null  $malwareScanner  - Scanner override; defaults to container binding or config-built YaraXScanner
      */
     public function __construct(
         string $diskName,
@@ -94,7 +100,8 @@ class AttachmentService
         ?string $pivotTable = null,
         ?string $foreignKey = null,
         ?callable $pathBuilder = null,
-        ?callable $scopeResolver = null
+        ?callable $scopeResolver = null,
+        ?MalwareScanner $malwareScanner = null
     ) {
         $this->diskName = $diskName;
         $this->attachmentModel = $attachmentModel;
@@ -102,6 +109,7 @@ class AttachmentService
         $this->foreignKey = $foreignKey;
         $this->pathBuilder = $pathBuilder;
         $this->scopeResolver = $scopeResolver;
+        $this->malwareScanner = $malwareScanner;
     }
 
     public function __destruct()
@@ -133,6 +141,10 @@ class AttachmentService
             if (! is_array($files)) {
                 $files = [$files];
             }
+
+            // Scan the raw uploads before any resize/re-encode or upload so a
+            // rejected file is never transformed and never leaves the tmp dir.
+            $this->scanForMalware($files);
 
             // Resize images first when the subclass has opted in. Non-image uploads
             // and resize-disabled subclasses fall through untouched.
@@ -444,6 +456,100 @@ class AttachmentService
                 ]);
             }
         }
+    }
+
+    // ========================================================================
+    // Malware scanning — opt-in via attachments.malware_scan config.
+    // ========================================================================
+
+    /**
+     * Scan raw uploads and reject the whole request on a match. No-op unless
+     * `attachments.malware_scan.enabled` is true, so the scanner is never even
+     * resolved for consumers that haven't opted in.
+     *
+     * Scan failures (engine missing/broken/timeout) reject the request too
+     * (fail closed) unless `fail_open` is set, which logs and continues.
+     * Detections always reject; fail_open never bypasses a match.
+     *
+     * @param  array  $files  Mixed array; only UploadedFile entries are scanned
+     *
+     * @throws MalwareDetectedException on a rule match (HTTP 422)
+     * @throws MalwareScanFailedException on scan failure when fail closed (HTTP 503)
+     */
+    protected function scanForMalware(array $files): void
+    {
+        if (! config('attachments.malware_scan.enabled', false)) {
+            return;
+        }
+
+        $failOpen = (bool) config('attachments.malware_scan.fail_open', false);
+
+        foreach ($files as $file) {
+            if (! $file instanceof UploadedFile) {
+                continue;
+            }
+
+            $filename = $file->getClientOriginalName();
+
+            try {
+                $path = $file->getRealPath();
+                if ($path === false || ! is_file($path)) {
+                    throw new MalwareScanFailedException('Upload tmp file is not readable for malware scan.');
+                }
+
+                $matches = $this->malwareScanner()->scan($path);
+            } catch (Throwable $e) {
+                // Custom scanner backends may throw anything; normalize so the
+                // fail-closed / fail_open semantics hold for every failure
+                // shape instead of leaking a generic 500.
+                if (! $e instanceof MalwareScanFailedException) {
+                    $e = new MalwareScanFailedException('Malware scanner threw an unexpected error.', $e);
+                }
+
+                if (! $failOpen) {
+                    Log::error('Malware scan failed - rejecting upload (fail closed)', [
+                        'file_name' => $filename,
+                        'error' => $e->getMessage(),
+                        'extra' => $e->getExtra(),
+                        'exception' => $e,
+                    ]);
+                    throw $e;
+                }
+
+                Log::warning('Malware scan failed - allowing upload (fail_open enabled)', [
+                    'file_name' => $filename,
+                    'error' => $e->getMessage(),
+                    'extra' => $e->getExtra(),
+                    'exception' => $e,
+                ]);
+
+                continue;
+            }
+
+            if ($matches !== []) {
+                Log::warning('Malware detected in upload - rejecting request', [
+                    'file_name' => $filename,
+                    'matched_rules' => $matches,
+                ]);
+                throw new MalwareDetectedException($filename, $matches);
+            }
+        }
+    }
+
+    /**
+     * Resolve the scanner lazily and cache it: constructor injection wins,
+     * then a container binding of the MalwareScanner interface, then a
+     * YaraXScanner built from config. Only called when scanning is enabled.
+     */
+    protected function malwareScanner(): MalwareScanner
+    {
+        if ($this->malwareScanner === null) {
+            $this->malwareScanner = app()->bound(MalwareScanner::class)
+                ? app(MalwareScanner::class)
+                : YaraXScanner::fromConfig((array) config('attachments.malware_scan', []));
+        }
+
+        return $this->malwareScanner;
     }
 
     // ========================================================================

--- a/src/Services/YaraXScanner.php
+++ b/src/Services/YaraXScanner.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Services;
+
+use JsonException;
+use NuiMarkets\LaravelSharedUtils\Contracts\MalwareScanner;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+/**
+ * MalwareScanner backed by the YARA-X CLI (`yr scan`), invoked as a separate
+ * process so a scanner crash can never take the PHP worker down.
+ *
+ * CLI contract (verified against yara-x 1.19.0):
+ *  - `yr scan --output-format=json <rules> <file>` prints a single JSON object
+ *    `{"version": "...", "matches": [{"rule": "...", "file": "..."}]}`.
+ *  - Exit code 0 for BOTH match and clean; the verdict is only in `matches`.
+ *  - An unreadable/missing TARGET file also exits 0 with empty matches and the
+ *    error on stderr only — parsing stdout alone would silently fail open, so
+ *    any stderr output fails the scan.
+ *  - A missing/invalid RULES path exits non-zero.
+ */
+class YaraXScanner implements MalwareScanner
+{
+    /**
+     * Cap on engine stdout/stderr captured into exception extra, so a
+     * misbehaving scanner can't flood logs or Sentry payloads.
+     */
+    private const OUTPUT_CAP = 1000;
+
+    public function __construct(
+        protected string $binary,
+        protected string $rulesPath,
+        protected bool $compiledRules = false,
+        protected int $timeoutSeconds = 10,
+    ) {}
+
+    /**
+     * Build a scanner from an `attachments.malware_scan` shaped config array.
+     */
+    public static function fromConfig(array $config): self
+    {
+        $rulesPath = $config['rules_path'] ?? null;
+        $useDefaultRules = ! is_string($rulesPath) || $rulesPath === '';
+        if ($useDefaultRules) {
+            $rulesPath = self::defaultRulesPath();
+        }
+
+        $timeoutSeconds = (int) ($config['timeout_seconds'] ?? 10);
+        if ($timeoutSeconds <= 0) {
+            $timeoutSeconds = 10;
+        }
+
+        return new self(
+            binary: $config['binary'] ?? 'yr',
+            rulesPath: $rulesPath,
+            // The baseline ruleset is plain .yar source; honoring a stray
+            // compiled_rules=true against it would fail every scan (closed).
+            // The flag only applies to an explicitly configured rules_path.
+            compiledRules: ! $useDefaultRules && (bool) ($config['compiled_rules'] ?? false),
+            timeoutSeconds: $timeoutSeconds,
+        );
+    }
+
+    /**
+     * Baseline ruleset shipped with the package (EICAR + generic indicators).
+     */
+    public static function defaultRulesPath(): string
+    {
+        return dirname(__DIR__, 2).'/resources/malware-rules';
+    }
+
+    public function scan(string $path): array
+    {
+        if (! is_file($path) || ! is_readable($path)) {
+            throw new MalwareScanFailedException('Malware scan target is not readable.');
+        }
+
+        if (! file_exists($this->rulesPath) || ! is_readable($this->rulesPath)) {
+            throw new MalwareScanFailedException('Malware scan rules path is not readable.', extra: [
+                'rules_path' => $this->rulesPath,
+            ]);
+        }
+
+        $command = [$this->binary, 'scan', '--output-format=json', '--disable-warnings'];
+        if ($this->compiledRules) {
+            $command[] = '--compiled-rules';
+        }
+        $command[] = '--';
+        $command[] = $this->rulesPath;
+        $command[] = $path;
+
+        $process = new Process($command);
+        $process->setTimeout($this->timeoutSeconds);
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $e) {
+            throw new MalwareScanFailedException('Malware scan timed out.', $e, [
+                'timeout_seconds' => $this->timeoutSeconds,
+            ]);
+        } catch (Throwable $e) {
+            // Process start failures, e.g. binary missing or not executable.
+            throw new MalwareScanFailedException('Malware scanner could not be executed.', $e, [
+                'binary' => $this->binary,
+            ]);
+        }
+
+        $stderr = trim($process->getErrorOutput());
+
+        if (! $process->isSuccessful() || $stderr !== '') {
+            throw new MalwareScanFailedException('Malware scan did not complete cleanly.', null, [
+                'exit_code' => $process->getExitCode(),
+                'stderr' => $this->capOutput($stderr),
+            ]);
+        }
+
+        return $this->parseMatches($process->getOutput());
+    }
+
+    /**
+     * Cap engine output for logs/Sentry without splitting a multibyte
+     * character at the boundary.
+     */
+    private function capOutput(string $output): string
+    {
+        return mb_strcut($output, 0, self::OUTPUT_CAP);
+    }
+
+    /**
+     * Parse matched rule identifiers out of the engine's JSON stdout. Strict:
+     * anything other than a well-formed `matches` list of `{rule: string}`
+     * entries is a scan failure, never a clean verdict.
+     *
+     * @return list<string>
+     */
+    protected function parseMatches(string $stdout): array
+    {
+        try {
+            $decoded = json_decode($stdout, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new MalwareScanFailedException('Malware scan output was not valid JSON.', $e, [
+                'stdout' => $this->capOutput($stdout),
+            ]);
+        }
+
+        if (! is_array($decoded) || ! isset($decoded['matches']) || ! is_array($decoded['matches'])) {
+            throw new MalwareScanFailedException('Malware scan output had no matches list.', null, [
+                'stdout' => $this->capOutput($stdout),
+            ]);
+        }
+
+        $rules = [];
+
+        foreach ($decoded['matches'] as $match) {
+            $rule = is_array($match) ? ($match['rule'] ?? null) : null;
+
+            if (! is_string($rule) || $rule === '') {
+                throw new MalwareScanFailedException('Malware scan output contained a malformed match entry.', null, [
+                    'stdout' => $this->capOutput($stdout),
+                ]);
+            }
+
+            $rules[] = $rule;
+        }
+
+        return array_values(array_unique($rules));
+    }
+}

--- a/src/Testing/FakeMalwareScanner.php
+++ b/src/Testing/FakeMalwareScanner.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Testing;
+
+use NuiMarkets\LaravelSharedUtils\Contracts\MalwareScanner;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
+
+/**
+ * In-memory MalwareScanner double so tests never need a real scanner binary.
+ *
+ * Usage:
+ *   $scanner = FakeMalwareScanner::clean();
+ *   $scanner = FakeMalwareScanner::detecting(['Test_Rule']);
+ *   $scanner = FakeMalwareScanner::detectingContent('EICAR', ['Eicar_Rule']);
+ *   $scanner = FakeMalwareScanner::failing('Simulated engine outage');
+ *
+ * Every scanned path is recorded in $scannedPaths for ordering/coverage
+ * assertions.
+ */
+class FakeMalwareScanner implements MalwareScanner
+{
+    /** @var callable(string): list<string> */
+    private $verdict;
+
+    /** @var list<string> Paths passed to scan(), in call order. */
+    public array $scannedPaths = [];
+
+    private function __construct(callable $verdict)
+    {
+        $this->verdict = $verdict;
+    }
+
+    /** Every file scans clean. */
+    public static function clean(): self
+    {
+        return new self(fn (): array => []);
+    }
+
+    /** Every file matches $rules. */
+    public static function detecting(array $rules = ['Fake_Malware_Rule']): self
+    {
+        return new self(fn (): array => $rules);
+    }
+
+    /** Files whose content contains $needle match $rules; everything else is clean. */
+    public static function detectingContent(string $needle, array $rules = ['Fake_Malware_Rule']): self
+    {
+        return new self(function (string $path) use ($needle, $rules): array {
+            return str_contains((string) file_get_contents($path), $needle) ? $rules : [];
+        });
+    }
+
+    /** Every scan throws MalwareScanFailedException (simulated engine failure). */
+    public static function failing(string $message = 'Simulated malware scan failure.'): self
+    {
+        return new self(function () use ($message): array {
+            throw new MalwareScanFailedException($message);
+        });
+    }
+
+    public function scan(string $path): array
+    {
+        $this->scannedPaths[] = $path;
+
+        return ($this->verdict)($path);
+    }
+}

--- a/tests/Feature/AttachmentServiceProviderTest.php
+++ b/tests/Feature/AttachmentServiceProviderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Feature;
+
+use Illuminate\Support\ServiceProvider;
+use NuiMarkets\LaravelSharedUtils\AttachmentServiceProvider;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+class AttachmentServiceProviderTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            AttachmentServiceProvider::class,
+        ];
+    }
+
+    public function test_provider_merges_inert_malware_scan_defaults()
+    {
+        $this->assertFalse(config('attachments.malware_scan.enabled'));
+        $this->assertFalse(config('attachments.malware_scan.fail_open'));
+        $this->assertSame('yr', config('attachments.malware_scan.binary'));
+        $this->assertNull(config('attachments.malware_scan.rules_path'));
+        $this->assertFalse(config('attachments.malware_scan.compiled_rules'));
+        $this->assertSame(10, config('attachments.malware_scan.timeout_seconds'));
+    }
+
+    public function test_provider_publishes_attachments_config()
+    {
+        $paths = ServiceProvider::pathsToPublish(AttachmentServiceProvider::class, 'attachments-config');
+
+        $this->assertCount(1, $paths);
+        $this->assertStringEndsWith('config/attachments.php', array_key_first($paths));
+    }
+}

--- a/tests/Feature/Exceptions/BaseErrorHandlerTest.php
+++ b/tests/Feature/Exceptions/BaseErrorHandlerTest.php
@@ -2,12 +2,14 @@
 
 namespace NuiMarkets\LaravelSharedUtils\Tests\Feature\Exceptions;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use NuiMarkets\LaravelSharedUtils\Exceptions\BaseErrorHandler;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareDetectedException;
 use NuiMarkets\LaravelSharedUtils\Exceptions\RemoteServiceException;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -78,6 +80,25 @@ class BaseErrorHandlerTest extends TestCase
         $this->assertEquals('Service Unavailable', $data['meta']['message']);
         $this->assertEquals(503, $data['meta']['status']);
         $this->assertEquals('Unable to connect to payment service', $data['errors'][0]['detail']);
+    }
+
+    public function test_malware_detected_response_does_not_leak_detection_internals()
+    {
+        // Rule ids, engine output, and paths live in the exception extra for
+        // logs/Sentry; the client response must never include them outside
+        // debug mode.
+        config()->set('app.debug', false);
+        $request = Request::create('/test', 'POST');
+
+        $exception = new MalwareDetectedException('invoice.pdf', ['Secret_Detection_Rule']);
+        $response = $this->handler->render($request, $exception);
+
+        $this->assertEquals(422, $response->getStatusCode());
+
+        $content = $response->getContent();
+        $this->assertStringContainsString('invoice.pdf', $content);
+        $this->assertStringNotContainsString('Secret_Detection_Rule', $content);
+        $this->assertStringNotContainsString('matched_rules', $content);
     }
 
     public function test_remote_service_exception_with_tags_and_extra()
@@ -332,7 +353,7 @@ class BaseErrorHandlerTest extends TestCase
         $previousException = new \Exception('Invalid UUID');
 
         // Use reflection to determine the correct constructor signature
-        $reflection = new \ReflectionClass(\Illuminate\Database\QueryException::class);
+        $reflection = new \ReflectionClass(QueryException::class);
         $constructor = $reflection->getConstructor();
         $parameters = $constructor->getParameters();
 
@@ -341,7 +362,7 @@ class BaseErrorHandlerTest extends TestCase
 
         if ($paramCount >= 4) {
             // Laravel 10.x+ signature: connectionName, sql, bindings, previous
-            $exception = new \Illuminate\Database\QueryException(
+            $exception = new QueryException(
                 'pgsql',
                 'SELECT * FROM orders WHERE id = ?',
                 ['invalid-uuid'],
@@ -354,14 +375,14 @@ class BaseErrorHandlerTest extends TestCase
 
             if ($secondParamType && $secondParamType->getName() === 'array') {
                 // Laravel 9.x prefer-lowest signature: connectionName, bindings, previous
-                $exception = new \Illuminate\Database\QueryException(
+                $exception = new QueryException(
                     'pgsql',
                     ['invalid-uuid'],
                     $previousException
                 );
             } else {
                 // Laravel 9.x signature: connectionName, sql, previous
-                $exception = new \Illuminate\Database\QueryException(
+                $exception = new QueryException(
                     'pgsql',
                     'SELECT * FROM orders WHERE id = ?',
                     $previousException
@@ -369,7 +390,7 @@ class BaseErrorHandlerTest extends TestCase
             }
         } else {
             // Laravel 8.x or other fallback: connectionName, previous
-            $exception = new \Illuminate\Database\QueryException(
+            $exception = new QueryException(
                 'pgsql',
                 $previousException
             );

--- a/tests/Feature/YaraXScannerIntegrationTest.php
+++ b/tests/Feature/YaraXScannerIntegrationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Feature;
+
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
+use NuiMarkets\LaravelSharedUtils\Services\YaraXScanner;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * Opt-in integration test against a real YARA-X binary and the baseline
+ * ruleset shipped in resources/malware-rules. Skipped unless the binary is
+ * available: set YARA_X_BINARY=/path/to/yr or have `yr` on PATH.
+ */
+class YaraXScannerIntegrationTest extends TestCase
+{
+    private string $binary;
+
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $binary = $this->locateBinary();
+        if ($binary === null) {
+            $this->markTestSkipped('YARA-X binary not available; set YARA_X_BINARY or put `yr` on PATH');
+        }
+        $this->binary = $binary;
+
+        $this->tmpDir = sys_get_temp_dir().'/yara_integration_test_'.uniqid();
+        mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->tmpDir)) {
+            foreach (glob($this->tmpDir.'/*') ?: [] as $f) {
+                @unlink($f);
+            }
+            @rmdir($this->tmpDir);
+        }
+        parent::tearDown();
+    }
+
+    private function locateBinary(): ?string
+    {
+        $env = getenv('YARA_X_BINARY');
+        if (is_string($env) && $env !== '' && is_executable($env)) {
+            return $env;
+        }
+
+        $which = trim((string) shell_exec('command -v yr 2>/dev/null'));
+
+        return $which !== '' ? $which : null;
+    }
+
+    private function scanner(): YaraXScanner
+    {
+        return new YaraXScanner($this->binary, YaraXScanner::defaultRulesPath());
+    }
+
+    /**
+     * The EICAR test string, assembled at runtime so the repo checkout itself
+     * doesn't trip antivirus scanners.
+     */
+    private function eicarContent(): string
+    {
+        return 'X5O!P%@AP[4\PZX54(P^)7CC)7}$'.'EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*';
+    }
+
+    public function test_detects_eicar_with_baseline_rules()
+    {
+        $path = $this->tmpDir.'/eicar.pdf';
+        file_put_contents($path, $this->eicarContent());
+
+        $matches = $this->scanner()->scan($path);
+
+        $this->assertContains('EICAR_Test_File', $matches);
+    }
+
+    public function test_detects_obfuscated_php_eval_with_baseline_rules()
+    {
+        $path = $this->tmpDir.'/upload.pdf';
+        file_put_contents($path, '<?php eval(base64_decode("cGhwaW5mbygpOw==")); ?>');
+
+        $matches = $this->scanner()->scan($path);
+
+        $this->assertContains('PHP_Webshell_Obfuscated_Eval', $matches);
+    }
+
+    public function test_clean_file_returns_no_matches()
+    {
+        $path = $this->tmpDir.'/clean.txt';
+        file_put_contents($path, 'perfectly ordinary document content');
+
+        $this->assertSame([], $this->scanner()->scan($path));
+    }
+
+    public function test_real_binary_with_bad_rules_path_is_scan_failure()
+    {
+        $path = $this->tmpDir.'/clean.txt';
+        file_put_contents($path, 'content');
+
+        $scanner = new YaraXScanner($this->binary, $this->tmpDir.'/missing-rules');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $scanner->scan($path);
+    }
+
+    public function test_real_binary_with_unreadable_target_is_scan_failure()
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('root can read anything; permission check not testable');
+        }
+
+        $path = $this->tmpDir.'/eicar.pdf';
+        file_put_contents($path, $this->eicarContent());
+        chmod($path, 0000);
+
+        try {
+            $this->expectException(MalwareScanFailedException::class);
+            $this->scanner()->scan($path);
+        } finally {
+            chmod($path, 0644);
+        }
+    }
+
+    public function test_compiled_baseline_rules_detect_eicar()
+    {
+        $compiled = $this->tmpDir.'/baseline.yarc';
+        $compile = new Process([
+            $this->binary, 'compile', '--output', $compiled, YaraXScanner::defaultRulesPath(),
+        ]);
+        $compile->mustRun();
+
+        $path = $this->tmpDir.'/eicar.pdf';
+        file_put_contents($path, $this->eicarContent());
+
+        $scanner = new YaraXScanner($this->binary, $compiled, compiledRules: true);
+
+        $this->assertContains('EICAR_Test_File', $scanner->scan($path));
+    }
+}

--- a/tests/Unit/Exceptions/MalwareExceptionsTest.php
+++ b/tests/Unit/Exceptions/MalwareExceptionsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Exceptions;
+
+use NuiMarkets\LaravelSharedUtils\Exceptions\BaseHttpRequestException;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareDetectedException;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+class MalwareExceptionsTest extends TestCase
+{
+    public function test_malware_detected_maps_to_422()
+    {
+        $e = new MalwareDetectedException('invoice.pdf', ['Rule_A', 'Rule_B']);
+
+        $this->assertInstanceOf(BaseHttpRequestException::class, $e);
+        $this->assertSame(422, $e->getStatusCode());
+        $this->assertSame(['Rule_A', 'Rule_B'], $e->getMatchedRules());
+    }
+
+    public function test_malware_detected_message_names_file_but_not_rules()
+    {
+        $e = new MalwareDetectedException('invoice.pdf', ['Secret_Detection_Rule']);
+
+        // Filename helps the client identify the offending upload; rule ids
+        // would disclose detection logic, so they stay in extra (logs/Sentry).
+        $this->assertStringContainsString('invoice.pdf', $e->getMessage());
+        $this->assertStringNotContainsString('Secret_Detection_Rule', $e->getMessage());
+        $this->assertSame(['Secret_Detection_Rule'], $e->getExtra()['matched_rules']);
+        $this->assertSame(['malware_scan' => 'detected'], $e->getTags());
+    }
+
+    public function test_malware_scan_failed_maps_to_503()
+    {
+        $previous = new \RuntimeException('boom');
+        $e = new MalwareScanFailedException('Malware scan timed out.', $previous, ['timeout_seconds' => 10]);
+
+        $this->assertInstanceOf(BaseHttpRequestException::class, $e);
+        $this->assertSame(503, $e->getStatusCode());
+        $this->assertSame(['timeout_seconds' => 10], $e->getExtra());
+        $this->assertSame(['malware_scan' => 'failed'], $e->getTags());
+        $this->assertSame($previous, $e->getPrevious());
+    }
+}

--- a/tests/Unit/Services/AttachmentServiceMalwareScanTest.php
+++ b/tests/Unit/Services/AttachmentServiceMalwareScanTest.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Services;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use NuiMarkets\LaravelSharedUtils\Contracts\MalwareScanner;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareDetectedException;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
+use NuiMarkets\LaravelSharedUtils\Services\AttachmentService;
+use NuiMarkets\LaravelSharedUtils\Testing\FakeMalwareScanner;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+/**
+ * processAttachments() malware-scan behavior with a fake scanner. Uses the
+ * TestAttachment / TestEntity stubs declared in AttachmentServiceTest.php
+ * (same namespace, loaded with the suite).
+ */
+class AttachmentServiceMalwareScanTest extends TestCase
+{
+    private const INFECTED_MARKER = 'FAKE-MALWARE-MARKER';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('test-disk');
+
+        $this->app['db']->connection()->getSchemaBuilder()->create('attachments', function ($table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->string('tenant_uuid')->nullable();
+            $table->string('file_name');
+            $table->unsignedBigInteger('file_size');
+            $table->string('bucket_path');
+            $table->string('type', 50);
+            $table->unsignedBigInteger('created_by');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        $this->app['db']->connection()->getSchemaBuilder()->create('test_entities', function ($table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->string('tenant_uuid')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function enableScan(array $overrides = []): void
+    {
+        config()->set('attachments.malware_scan', array_merge([
+            'enabled' => true,
+            'binary' => 'yr',
+            'rules_path' => null,
+            'compiled_rules' => false,
+            'timeout_seconds' => 10,
+            'fail_open' => false,
+        ], $overrides));
+    }
+
+    private function makeService(?MalwareScanner $scanner = null): AttachmentService
+    {
+        return new AttachmentService(
+            'test-disk',
+            TestAttachment::class,
+            'test_attachments',
+            'entity_id',
+            null,
+            null,
+            $scanner
+        );
+    }
+
+    private function makeEntity(): TestEntity
+    {
+        $entity = new TestEntity(['id' => 1, 'tenant_uuid' => 'tenant-123']);
+        $entity->exists = true;
+        $entity->save();
+
+        return $entity;
+    }
+
+    private function assertNothingStored(): void
+    {
+        $this->assertCount(0, Storage::disk('test-disk')->allFiles(), 'Expected zero files in storage');
+        $this->assertSame(0, TestAttachment::count(), 'Expected zero attachment rows');
+    }
+
+    public function test_disabled_scan_never_invokes_injected_scanner()
+    {
+        // Default config: malware_scan disabled. A scanner that would fail
+        // every scan proves scanning is never attempted.
+        $scanner = FakeMalwareScanner::failing();
+        $service = $this->makeService($scanner);
+
+        $attachments = $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+
+        $this->assertCount(1, $attachments);
+        $this->assertSame([], $scanner->scannedPaths);
+    }
+
+    public function test_disabled_scan_never_resolves_scanner_from_config()
+    {
+        // No injected scanner, no container binding, binary that cannot exist:
+        // if the scanner were resolved and run, this would throw.
+        config()->set('attachments.malware_scan.binary', '/nonexistent/yr');
+
+        $service = $this->makeService();
+
+        $attachments = $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+
+        $this->assertCount(1, $attachments);
+    }
+
+    public function test_infected_file_rejects_whole_request_and_stores_nothing()
+    {
+        $this->enableScan();
+        $scanner = FakeMalwareScanner::detectingContent(self::INFECTED_MARKER, ['Fake_Rule']);
+        $service = $this->makeService($scanner);
+
+        $files = [
+            UploadedFile::fake()->createWithContent('clean.pdf', 'harmless content'),
+            UploadedFile::fake()->createWithContent('bad.pdf', 'payload '.self::INFECTED_MARKER),
+        ];
+
+        $thrown = null;
+
+        try {
+            $service->processAttachments($this->makeEntity(), $files);
+        } catch (MalwareDetectedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'Expected MalwareDetectedException');
+        $this->assertSame(422, $thrown->getStatusCode());
+        $this->assertSame(['Fake_Rule'], $thrown->getMatchedRules());
+        $this->assertStringContainsString('bad.pdf', $thrown->getMessage());
+        $this->assertNothingStored();
+    }
+
+    public function test_clean_files_upload_normally_when_scan_enabled()
+    {
+        $this->enableScan();
+        $scanner = FakeMalwareScanner::clean();
+        $service = $this->makeService($scanner);
+
+        $attachments = $service->processAttachments($this->makeEntity(), [
+            UploadedFile::fake()->image('one.jpg'),
+            UploadedFile::fake()->create('two.pdf', 10, 'application/pdf'),
+        ]);
+
+        $this->assertCount(2, $attachments);
+        $this->assertCount(2, $scanner->scannedPaths);
+        foreach ($attachments as $attachment) {
+            Storage::disk('test-disk')->assertExists($attachment->bucket_path);
+        }
+    }
+
+    public function test_scan_failure_rejects_request_by_default()
+    {
+        $this->enableScan();
+        $service = $this->makeService(FakeMalwareScanner::failing());
+
+        $thrown = null;
+
+        try {
+            $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+        } catch (MalwareScanFailedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'Expected MalwareScanFailedException (fail closed)');
+        $this->assertSame(503, $thrown->getStatusCode());
+        $this->assertNothingStored();
+    }
+
+    public function test_scan_failure_with_fail_open_allows_upload_and_logs_warning()
+    {
+        Log::spy();
+
+        $this->enableScan(['fail_open' => true]);
+        $service = $this->makeService(FakeMalwareScanner::failing());
+
+        $attachments = $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+
+        $this->assertCount(1, $attachments);
+        Log::shouldHaveReceived('warning')->withArgs(
+            fn ($message) => str_contains((string) $message, 'fail_open')
+        )->once();
+    }
+
+    public function test_unexpected_scanner_exception_is_normalized_and_fails_closed()
+    {
+        // A custom scanner backend throwing something other than
+        // MalwareScanFailedException must still fail closed as a 503, not
+        // surface as a generic 500.
+        $this->enableScan();
+        $service = $this->makeService($this->throwingScanner());
+
+        $thrown = null;
+
+        try {
+            $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+        } catch (MalwareScanFailedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'Expected normalized MalwareScanFailedException');
+        $this->assertSame(503, $thrown->getStatusCode());
+        $this->assertInstanceOf(\RuntimeException::class, $thrown->getPrevious());
+        $this->assertNothingStored();
+    }
+
+    public function test_unexpected_scanner_exception_respects_fail_open()
+    {
+        $this->enableScan(['fail_open' => true]);
+        $service = $this->makeService($this->throwingScanner());
+
+        $attachments = $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+
+        $this->assertCount(1, $attachments);
+    }
+
+    private function throwingScanner(): MalwareScanner
+    {
+        return new class implements MalwareScanner
+        {
+            public function scan(string $path): array
+            {
+                throw new \RuntimeException('unexpected backend explosion');
+            }
+        };
+    }
+
+    public function test_detection_rejects_even_with_fail_open()
+    {
+        // fail_open only covers scan FAILURES; a detection always rejects.
+        $this->enableScan(['fail_open' => true]);
+        $service = $this->makeService(FakeMalwareScanner::detecting(['Fake_Rule']));
+
+        $this->expectException(MalwareDetectedException::class);
+        $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('bad.jpg'));
+    }
+
+    public function test_container_binding_resolves_scanner_when_none_injected()
+    {
+        $this->enableScan();
+        $scanner = FakeMalwareScanner::detecting(['Bound_Rule']);
+        $this->app->instance(MalwareScanner::class, $scanner);
+
+        $service = $this->makeService();
+
+        $thrown = null;
+
+        try {
+            $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('bad.jpg'));
+        } catch (MalwareDetectedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown);
+        $this->assertSame(['Bound_Rule'], $thrown->getMatchedRules());
+        $this->assertCount(1, $scanner->scannedPaths);
+    }
+
+    public function test_constructor_injection_wins_over_container_binding()
+    {
+        $this->enableScan();
+        $boundScanner = FakeMalwareScanner::detecting(['Bound_Rule']);
+        $this->app->instance(MalwareScanner::class, $boundScanner);
+
+        $injectedScanner = FakeMalwareScanner::clean();
+        $service = $this->makeService($injectedScanner);
+
+        $attachments = $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+
+        $this->assertCount(1, $attachments);
+        $this->assertCount(1, $injectedScanner->scannedPaths);
+        $this->assertSame([], $boundScanner->scannedPaths);
+    }
+
+    public function test_config_fallback_builds_real_scanner_which_fails_closed_without_binary()
+    {
+        // No injection, no binding: the service builds a YaraXScanner from
+        // config. With a nonexistent binary the scan fails and, fail closed,
+        // rejects the upload.
+        $this->enableScan(['binary' => '/nonexistent/yr-binary']);
+
+        $service = $this->makeService();
+
+        $this->expectException(MalwareScanFailedException::class);
+        $service->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+    }
+
+    public function test_scan_runs_on_raw_bytes_before_resize()
+    {
+        $this->enableScan();
+        $scanner = FakeMalwareScanner::detecting(['Fake_Rule']);
+        $service = new MalwareScanResizingAttachmentService($scanner);
+
+        $file = UploadedFile::fake()->image('avatar.jpg', 800, 800);
+        $originalPath = $file->getRealPath();
+
+        $thrown = null;
+
+        try {
+            $service->processAttachments($this->makeEntity(), $file);
+        } catch (MalwareDetectedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown);
+        // The scanned path is the raw upload tmp file, not a resized_* copy —
+        // rejection happens before any re-encode.
+        $this->assertSame([$originalPath], $scanner->scannedPaths);
+        $this->assertNothingStored();
+    }
+}
+
+/**
+ * Resize-enabled subclass mirroring avatar/logo consumers, with a scanner
+ * injected through the parent constructor.
+ */
+class MalwareScanResizingAttachmentService extends AttachmentService
+{
+    protected ?array $imageResizeConfig = [
+        'max_width' => 400,
+        'max_height' => 400,
+        'quality' => 80,
+        'background' => 'ffffff',
+    ];
+
+    public function __construct(MalwareScanner $scanner)
+    {
+        parent::__construct(
+            'test-disk',
+            TestAttachment::class,
+            'test_attachments',
+            'entity_id',
+            null,
+            null,
+            $scanner
+        );
+    }
+}

--- a/tests/Unit/Services/YaraXScannerTest.php
+++ b/tests/Unit/Services/YaraXScannerTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Services;
+
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
+use NuiMarkets\LaravelSharedUtils\Services\YaraXScanner;
+use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
+
+/**
+ * Unit tests for YaraXScanner driven by stub executables (small shell scripts
+ * standing in for the yr binary), so the suite never needs YARA-X installed.
+ * The real-binary contract is covered by the opt-in
+ * Feature\YaraXScannerIntegrationTest.
+ */
+class YaraXScannerTest extends TestCase
+{
+    private string $workDir;
+
+    private string $targetFile;
+
+    private string $rulesFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->workDir = sys_get_temp_dir().'/yara_scanner_test_'.uniqid();
+        mkdir($this->workDir);
+
+        $this->targetFile = $this->workDir.'/target.txt';
+        file_put_contents($this->targetFile, 'scan me');
+
+        $this->rulesFile = $this->workDir.'/rules.yar';
+        file_put_contents($this->rulesFile, '// stub rules, never parsed by stub binaries');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir.'/*') ?: [] as $f) {
+            @chmod($f, 0644);
+            @unlink($f);
+        }
+        @rmdir($this->workDir);
+        parent::tearDown();
+    }
+
+    /**
+     * Write an executable shell script standing in for the yr binary.
+     */
+    private function stubBinary(string $body): string
+    {
+        $path = $this->workDir.'/yr_stub_'.uniqid();
+        file_put_contents($path, "#!/bin/sh\n{$body}\n");
+        chmod($path, 0755);
+
+        return $path;
+    }
+
+    private function scanner(string $binary, ?string $rulesPath = null, bool $compiledRules = false, int $timeoutSeconds = 10): YaraXScanner
+    {
+        return new YaraXScanner($binary, $rulesPath ?? $this->rulesFile, $compiledRules, $timeoutSeconds);
+    }
+
+    public function test_clean_scan_returns_empty_list()
+    {
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[]}\'');
+
+        $this->assertSame([], $this->scanner($binary)->scan($this->targetFile));
+    }
+
+    public function test_match_returns_deduplicated_rule_identifiers()
+    {
+        $binary = $this->stubBinary(
+            'echo \'{"version":"1.19.0","matches":[{"rule":"Rule_A","file":"/tmp/x"},{"rule":"Rule_B","file":"/tmp/x"},{"rule":"Rule_A","file":"/tmp/x"}]}\''
+        );
+
+        $this->assertSame(['Rule_A', 'Rule_B'], $this->scanner($binary)->scan($this->targetFile));
+    }
+
+    public function test_stderr_with_exit_zero_is_scan_failure()
+    {
+        // yr's most dangerous behavior: an unreadable TARGET file exits 0 with
+        // empty matches and the error on stderr only. Trusting stdout alone
+        // would silently fail open.
+        $binary = $this->stubBinary(
+            'echo \'{"version":"1.19.0","matches":[]}\'; echo \'error: can not open target\' >&2'
+        );
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->scanner($binary)->scan($this->targetFile);
+    }
+
+    public function test_nonzero_exit_is_scan_failure()
+    {
+        $binary = $this->stubBinary('echo \'error: bad rules\' >&2; exit 1');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->scanner($binary)->scan($this->targetFile);
+    }
+
+    public function test_invalid_json_output_is_scan_failure()
+    {
+        $binary = $this->stubBinary('echo \'not json at all\'');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->scanner($binary)->scan($this->targetFile);
+    }
+
+    public function test_missing_matches_key_is_scan_failure()
+    {
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0"}\'');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->scanner($binary)->scan($this->targetFile);
+    }
+
+    public function test_non_array_matches_is_scan_failure()
+    {
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":"clean"}\'');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->scanner($binary)->scan($this->targetFile);
+    }
+
+    public function test_match_entry_without_rule_is_scan_failure()
+    {
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[{"file":"/tmp/x"}]}\'');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->scanner($binary)->scan($this->targetFile);
+    }
+
+    public function test_timeout_is_scan_failure()
+    {
+        $binary = $this->stubBinary('sleep 3; echo \'{"version":"1.19.0","matches":[]}\'');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->expectExceptionMessage('timed out');
+        $this->scanner($binary, timeoutSeconds: 1)->scan($this->targetFile);
+    }
+
+    public function test_missing_binary_is_scan_failure()
+    {
+        $this->expectException(MalwareScanFailedException::class);
+        $this->scanner($this->workDir.'/does_not_exist')->scan($this->targetFile);
+    }
+
+    public function test_missing_target_file_is_scan_failure()
+    {
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[]}\'');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->expectExceptionMessage('target is not readable');
+        $this->scanner($binary)->scan($this->workDir.'/missing.txt');
+    }
+
+    public function test_unreadable_target_file_is_scan_failure()
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('root can read anything; permission check not testable');
+        }
+
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[]}\'');
+        chmod($this->targetFile, 0000);
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->expectExceptionMessage('target is not readable');
+        $this->scanner($binary)->scan($this->targetFile);
+    }
+
+    public function test_missing_rules_path_is_scan_failure()
+    {
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[]}\'');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->expectExceptionMessage('rules path is not readable');
+        $this->scanner($binary, rulesPath: $this->workDir.'/missing-rules.yar')->scan($this->targetFile);
+    }
+
+    public function test_invokes_binary_with_expected_arguments()
+    {
+        $argsFile = $this->workDir.'/args.txt';
+        $binary = $this->stubBinary(
+            'printf \'%s\n\' "$@" > '.escapeshellarg($argsFile).'; echo \'{"version":"1.19.0","matches":[]}\''
+        );
+
+        $this->scanner($binary)->scan($this->targetFile);
+
+        $args = file($argsFile, FILE_IGNORE_NEW_LINES);
+        $this->assertSame([
+            'scan',
+            '--output-format=json',
+            '--disable-warnings',
+            '--',
+            $this->rulesFile,
+            $this->targetFile,
+        ], $args);
+    }
+
+    public function test_compiled_rules_flag_added_when_configured()
+    {
+        $argsFile = $this->workDir.'/args.txt';
+        $binary = $this->stubBinary(
+            'printf \'%s\n\' "$@" > '.escapeshellarg($argsFile).'; echo \'{"version":"1.19.0","matches":[]}\''
+        );
+
+        $this->scanner($binary, compiledRules: true)->scan($this->targetFile);
+
+        $args = file($argsFile, FILE_IGNORE_NEW_LINES);
+        $this->assertContains('--compiled-rules', $args);
+    }
+
+    public function test_scan_failure_extra_caps_captured_stderr()
+    {
+        $binary = $this->stubBinary('head -c 5000 /dev/zero | tr \'\0\' \'e\' >&2; exit 1');
+
+        try {
+            $this->scanner($binary)->scan($this->targetFile);
+            $this->fail('Expected MalwareScanFailedException');
+        } catch (MalwareScanFailedException $e) {
+            $this->assertLessThanOrEqual(1000, strlen($e->getExtra()['stderr']));
+        }
+    }
+
+    public function test_from_config_uses_defaults()
+    {
+        $scanner = YaraXScanner::fromConfig([]);
+
+        $reflection = new \ReflectionClass($scanner);
+        $this->assertSame('yr', $reflection->getProperty('binary')->getValue($scanner));
+        $this->assertSame(YaraXScanner::defaultRulesPath(), $reflection->getProperty('rulesPath')->getValue($scanner));
+        $this->assertFalse($reflection->getProperty('compiledRules')->getValue($scanner));
+        $this->assertSame(10, $reflection->getProperty('timeoutSeconds')->getValue($scanner));
+    }
+
+    public function test_from_config_respects_overrides()
+    {
+        $scanner = YaraXScanner::fromConfig([
+            'binary' => '/usr/local/bin/yr',
+            'rules_path' => '/etc/yara/rules.yarc',
+            'compiled_rules' => true,
+            'timeout_seconds' => 30,
+        ]);
+
+        $reflection = new \ReflectionClass($scanner);
+        $this->assertSame('/usr/local/bin/yr', $reflection->getProperty('binary')->getValue($scanner));
+        $this->assertSame('/etc/yara/rules.yarc', $reflection->getProperty('rulesPath')->getValue($scanner));
+        $this->assertTrue($reflection->getProperty('compiledRules')->getValue($scanner));
+        $this->assertSame(30, $reflection->getProperty('timeoutSeconds')->getValue($scanner));
+    }
+
+    public function test_from_config_ignores_compiled_rules_for_default_rules_path()
+    {
+        // The baseline ruleset is .yar source; a stray compiled_rules=true
+        // must not apply to it (it would fail every scan, closed).
+        $scanner = YaraXScanner::fromConfig(['compiled_rules' => true]);
+
+        $reflection = new \ReflectionClass($scanner);
+        $this->assertFalse($reflection->getProperty('compiledRules')->getValue($scanner));
+        $this->assertSame(YaraXScanner::defaultRulesPath(), $reflection->getProperty('rulesPath')->getValue($scanner));
+    }
+
+    public function test_from_config_treats_non_positive_timeout_as_default()
+    {
+        foreach ([0, -5, ''] as $bad) {
+            $scanner = YaraXScanner::fromConfig(['timeout_seconds' => $bad]);
+
+            $reflection = new \ReflectionClass($scanner);
+            $this->assertSame(10, $reflection->getProperty('timeoutSeconds')->getValue($scanner));
+        }
+    }
+
+    public function test_default_rules_path_ships_with_package()
+    {
+        $this->assertDirectoryExists(YaraXScanner::defaultRulesPath());
+        $this->assertNotEmpty(glob(YaraXScanner::defaultRulesPath().'/*.yar'));
+    }
+}


### PR DESCRIPTION
## Summary
- `AttachmentService` can now scan every upload for malware before anything is resized, written to S3, or recorded in the DB. A rule match rejects the whole request with HTTP 422 (`MalwareDetectedException`) and stores nothing.
- Off by default and fully inert: unless `attachments.malware_scan.enabled` is true, the scanner is never resolved and `processAttachments()` behaves exactly as in 0.7.x.
- New `MalwareScanner` contract with a YARA-X CLI backend (`YaraXScanner`): process-isolated shell-out via Symfony Process (argv array, no shell), strict verdict handling. Non-zero exit, any stderr output, or malformed JSON counts as a scan failure, never a clean pass; `yr` exits 0 with an empty match list when the target file is unreadable (error goes to stderr only), so trusting stdout alone would silently fail open.
- Scan failures (binary missing, engine error, timeout) fail closed with HTTP 503 (`MalwareScanFailedException`) unless `fail_open=true` explicitly downgrades them to a logged warning. Detections always reject; `fail_open` never bypasses a match. Unexpected exceptions from custom scanner backends are normalized into the same semantics.
- Scanner resolution: optional trailing constructor parameter, then a container binding of `MalwareScanner`, then a config-built `YaraXScanner`. Rule ids stay out of client-facing messages (they would disclose detection logic) and travel in the exception `extra` for logs/Sentry.
- Ships a baseline ruleset (EICAR + conservative webshell indicators) so any deployment can verify the pipeline end to end; production deployments point `rules_path` at a curated set (`.yar` file/dir or precompiled `.yarc`). Includes `FakeMalwareScanner` for consumer test suites and a full guide in `docs/malware-scanning.md`.
- composer: `symfony/process ^7.0` is now an explicit dependency (used directly; previously transitive). the CI matrix install step sets `COMPOSER_NO_SECURITY_BLOCKING=1` because composer 2.9+ blocks advisory-flagged versions at resolve time by default and the matrix intentionally pins Laravel 11/12 floor versions that are all advisory-flagged. The bypass is scoped to that one step; repo config keeps full security blocking for `composer update`/`require`.

## Review
Internal self-review, plus two external reviews (Codex agentic, Kimi) pre-push: no blocking findings survived triage; applied fixes include normalizing unexpected scanner exceptions into fail-closed/fail-open semantics, ignoring a stray `compiled_rules=true` for the baseline source ruleset, multibyte-safe output capping, a timeout floor, and a regression test proving detection internals never render in non-debug error responses.

## Test plan
- [x] 46 new tests: scanner CLI-contract matrix via stub binaries (stderr fail-open trap, timeouts, malformed JSON, argument construction, output capping), `processAttachments()` wiring (multi-file rejection stores zero files and zero rows, fail_open semantics, resolution precedence, scan-before-resize on raw bytes, disabled config never resolves the scanner), exceptions, provider config merge/publish, error-response leak guard
- [x] Opt-in integration tests against the real yara-x 1.19.0 binary (`YARA_X_BINARY` env): EICAR and webshell detection with the shipped ruleset, compiled `.yarc` flow, clean files pass, unreadable target fails closed
- [x] Full suite green on Laravel 12 prefer-stable (PHP 8.3, PHPUnit 12.5): 630 tests
- [x] Full suite green on Laravel 11.0 prefer-lowest floor (PHPUnit 10.5, symfony/process 7.0.0)
- [x] Pint clean on all changed files

## Backwards compatibility
- `enabled=false` (default): the scanner is never resolved; `processAttachments()` is behavior-identical to 0.7.2. Consumers that register `AttachmentServiceProvider` only gain inert config defaults.
- The new constructor parameter is optional and trailing; existing `new AttachmentService(...)` call sites are unaffected.
- `symfony/process ^7.0` was already installed transitively by Laravel 11/12, so no new install surface for consumers.
- Intended release: 0.8.0 (minor, additive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional malware scanning for file uploads, with configurable behavior for detections, failures, timeouts, and fail-open or fail-closed handling.
  * Added support for YARA-based rules and a real scanner integration path.
* **Bug Fixes**
  * Uploads now stop before storage when malware is detected, and error responses avoid exposing internal scan details.
* **Documentation**
  * Expanded setup and configuration guidance for malware scanning and attachment config publishing.
* **Tests**
  * Added coverage for scanner behavior, upload handling, and exception mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
