### PR TITLE
chore(ci): enable Dependabot github-actions version updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  # Keep GitHub Actions on supported (Node 24) runtimes; grouped into one PR.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Enable Dependabot version updates for the `github-actions` ecosystem so this repo's workflow actions stay on supported (Node 24) runtimes going forward. GitHub has deprecated Node 20 on Actions runners: actions still declaring `using: node20` currently force-run on Node 24 as a temporary fallback and will fail once that fallback is removed.
- Group all github-actions bumps into a single consolidated PR per run (not one PR per action) to keep review noise low.
- This repo had no Dependabot config, which is why its actions drifted stale. This matches the config the already-maintained service repos use.

## Test plan

- [ ] After merge, Dependabot opens a grouped `github-actions` bump PR
- [ ] That bump PR's CI passes
