### PR TITLE
fix(testing): fail loudly when DB setup can't reach a backing service

### DIFF
--- a/src/Testing/DBSetupExtension.php
+++ b/src/Testing/DBSetupExtension.php
@@ -19,6 +19,8 @@ use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade as PHPUnitExtensionFacade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
+use RuntimeException;
+use Throwable;
 
 /**
  * DB Setup Extension for PHPUnit to drop/create testing database with migrations run.
@@ -93,26 +95,123 @@ class DBSetupExtension implements Extension
         // Set the application instance for Facades
         Facade::setFacadeApplication($app);
 
-        $this->setTemporaryDefaultConnection();
-        $this->resetDatabase();
+        // A refused connection during setup almost always means a local
+        // backing service is down, not a schema/data fault. The guard
+        // translates that into a clear, early error and re-throws anything
+        // else unchanged.
+        $this->guardBackingServices(function () {
+            $this->setTemporaryDefaultConnection();
+            $this->resetDatabase();
 
-        app('db')->setDefaultConnection(env('DB_CONNECTION'));
+            app('db')->setDefaultConnection(env('DB_CONNECTION'));
 
-        $testing = Config::get('database.connections.testing');
+            $testing = Config::get('database.connections.testing');
 
-        Log::debug('Testing connection', [$testing]);
+            Log::debug('Testing connection', [$testing]);
 
-        $this->runMigrations();
+            $this->runMigrations();
 
-        $this->verifyMigrations();
+            $this->verifyMigrations();
 
-        $this->runSeeder();
+            $this->runSeeder();
+        });
 
         $endTime = microtime(true);
         $executionTime = round(($endTime - $startTime) * 1000);
 
         Log::warning("DB Setup done in {$executionTime}ms (migrate:fresh + db:seed)");
 
+    }
+
+    /**
+     * Run the DB-setup pipeline, translating a refused-connection failure into
+     * a clear, early error. Any other failure is re-thrown unchanged so real
+     * schema/data faults surface as themselves. Kept as its own method so the
+     * catch/translate/re-throw boundary is unit-testable without a bootstrapped
+     * application.
+     */
+    protected function guardBackingServices(callable $pipeline): void
+    {
+        try {
+            $pipeline();
+        } catch (Throwable $e) {
+            $this->failIfBackingServiceUnavailable($e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Translate a refused-connection failure during DB setup into a clear,
+     * early error naming the likely cause: a local backing service the test
+     * suite depends on (database and/or cache) is not running.
+     *
+     * Seeding can touch more than the database. A model event fired while
+     * seeding (for example one that flushes a response/redis cache on save)
+     * can reach a cache backend, so a refused connection here is usually "the
+     * local stack is down", not a schema or data problem. Left untranslated,
+     * the original failure surfaces as a buried driver trace, often behind an
+     * earlier SQL "Connection refused", which reads as a database fault and
+     * misdirects debugging.
+     *
+     * No-op when the failure is not a connection error; the caller then
+     * re-throws the original exception unchanged.
+     */
+    protected function failIfBackingServiceUnavailable(Throwable $e): void
+    {
+        if (! $this->isConnectionRefused($e)) {
+            return;
+        }
+
+        $message = 'Test DB setup could not reach a required backing service '
+            .'(database and/or cache). The local stack must be running before '
+            .'the test database can be built and seeded: start it and re-run. '
+            .'Original error: '.$e->getMessage();
+
+        $this->reportSetupFailure($message);
+
+        throw new RuntimeException($message, 0, $e);
+    }
+
+    /**
+     * Emit the setup-failure message straight to the console.
+     *
+     * This is the primary signal, not a nicety: the RuntimeException thrown by
+     * failIfBackingServiceUnavailable() bubbles through a PHPUnit event
+     * subscriber, where PHPUnit classifies a throwable originating outside its
+     * own source as a third-party-subscriber error, downgrades it to a warning,
+     * and does NOT re-throw (the run continues). Without this write the cause
+     * would be buried behind the earlier driver error. Overridable so tests can
+     * capture it instead of writing to the console.
+     */
+    protected function reportSetupFailure(string $message): void
+    {
+        fwrite(STDERR, PHP_EOL.'[DBSetupExtension] '.$message.PHP_EOL.PHP_EOL);
+    }
+
+    /**
+     * True when the throwable (or anything in its previous chain) looks like a
+     * refused TCP connection to a backing service: MySQL/Postgres via PDO, or
+     * Redis via predis/phpredis. Matches on message text so it stays
+     * client-agnostic across drivers.
+     *
+     * Scoped deliberately to "connection refused" (the observed failure mode
+     * for a down local stack). The canonical refused messages already carry
+     * that phrase, so matching the bare MySQL "[2002]" code is unnecessary and
+     * would mis-flag "[2002] No such file or directory" (a socket-path
+     * misconfiguration) as a stopped service.
+     */
+    protected function isConnectionRefused(Throwable $e): bool
+    {
+        $pattern = '/connection refused|actively refused/i';
+
+        for ($current = $e; $current !== null; $current = $current->getPrevious()) {
+            if (preg_match($pattern, $current->getMessage()) === 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function runMigrations(): void
@@ -218,7 +317,7 @@ class DBSetupExtension implements Extension
         $connection = app('db')->connection();
         $grammar = $connection->getQueryGrammar();
 
-        log::debug("Resetting the test database $dbName ...");
+        Log::debug("Resetting the test database $dbName ...");
 
         if ($connection->getDriverName() === 'pgsql') {
             Log::debug("Terminating pg connections on $dbName");
@@ -234,7 +333,7 @@ class DBSetupExtension implements Extension
         $connection->unprepared("DROP DATABASE IF EXISTS {$quotedName}");
         $connection->unprepared("CREATE DATABASE {$quotedName}");
 
-        log::info("Dropped/Created database: {$dbName}");
+        Log::info("Dropped/Created database: {$dbName}");
 
     }
 

--- a/tests/Unit/Testing/DBSetupExtensionTest.php
+++ b/tests/Unit/Testing/DBSetupExtensionTest.php
@@ -7,6 +7,7 @@ use Mockery;
 use NuiMarkets\LaravelSharedUtils\Testing\DBSetupExtension;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 use PHPUnit\Event\TestRunner\StartedSubscriber;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 class DBSetupExtensionTest extends TestCase
@@ -256,5 +257,179 @@ class DBSetupExtensionTest extends TestCase
 
         $this->assertArrayHasKey('temp', $connections, 'DatabaseManager should be able to resolve temp connection');
         $this->assertNull($connections['temp']['database']);
+    }
+
+    /**
+     * Subclass exposing the protected connection-failure seams so the
+     * translation logic can be exercised without a running stack. Captures the
+     * console write instead of emitting it, keeping the suite output clean.
+     */
+    private function connectionFailureExtension(): DBSetupExtension
+    {
+        return new class extends DBSetupExtension
+        {
+            /** @var list<string> */
+            public array $reported = [];
+
+            public function callIsConnectionRefused(\Throwable $e): bool
+            {
+                return $this->isConnectionRefused($e);
+            }
+
+            public function callFailIfBackingServiceUnavailable(\Throwable $e): void
+            {
+                $this->failIfBackingServiceUnavailable($e);
+            }
+
+            public function callGuardBackingServices(callable $pipeline): void
+            {
+                $this->guardBackingServices($pipeline);
+            }
+
+            protected function reportSetupFailure(string $message): void
+            {
+                $this->reported[] = $message;
+            }
+        };
+    }
+
+    /**
+     * Canonical refused-connection messages from the actual drivers. Every case
+     * carries the literal "connection refused" (or the Windows "actively
+     * refused"), which is exactly what the classifier keys on.
+     */
+    public static function refusedConnectionMessages(): array
+    {
+        return [
+            'mysql pdo refused' => ['SQLSTATE[HY000] [2002] Connection refused'],
+            'postgres pdo refused' => ['SQLSTATE[08006] [7] connection to server at "127.0.0.1", port 5432 failed: Connection refused'],
+            'redis initial connect refused' => ['Connection refused'],
+            'redis predis refused' => ['Connection refused [tcp://127.0.0.1:6379]'],
+            'windows actively refused' => ['No connection could be made because the target machine actively refused it'],
+            'mixed case' => ['CONNECTION REFUSED'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('refusedConnectionMessages')]
+    public function it_detects_refused_connections_across_drivers(string $message): void
+    {
+        $extension = $this->connectionFailureExtension();
+
+        $this->assertTrue($extension->callIsConnectionRefused(new \RuntimeException($message)));
+    }
+
+    #[Test]
+    public function it_detects_a_refused_connection_nested_in_the_previous_chain(): void
+    {
+        $root = new \RuntimeException('SQLSTATE[HY000] [2002] Connection refused');
+        $wrapped = new \RuntimeException('db:seed failed', 0, $root);
+
+        $this->assertTrue($this->connectionFailureExtension()->callIsConnectionRefused($wrapped));
+    }
+
+    /**
+     * Non-connection failures the classifier must NOT flag. The socket-path
+     * case (same MySQL [2002] code, different tail) is the reason the bare
+     * "[2002]" code is not matched: it is a misconfiguration, not a down stack.
+     */
+    public static function nonRefusedMessages(): array
+    {
+        return [
+            'schema fault' => ["SQLSTATE[42S02]: Base table or view not found: 1146 Table 'users' doesn't exist"],
+            'mysql socket missing' => ['SQLSTATE[HY000] [2002] No such file or directory'],
+            'unrelated seeding bug' => ['Undefined array key "sku"'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('nonRefusedMessages')]
+    public function it_does_not_flag_non_connection_failures(string $message): void
+    {
+        $this->assertFalse($this->connectionFailureExtension()->callIsConnectionRefused(new \RuntimeException($message)));
+    }
+
+    #[Test]
+    public function it_translates_a_refused_connection_into_a_clear_stack_error(): void
+    {
+        $extension = $this->connectionFailureExtension();
+        $original = new \RuntimeException('SQLSTATE[HY000] [2002] Connection refused');
+
+        try {
+            $extension->callFailIfBackingServiceUnavailable($original);
+            $this->fail('Expected a RuntimeException to be thrown');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('backing service', $e->getMessage());
+            $this->assertStringContainsString('local stack must be running', $e->getMessage());
+            $this->assertSame($original, $e->getPrevious(), 'Original cause should be preserved');
+        }
+
+        // The console write is the primary signal; it must fire once with the
+        // same message as the thrown exception.
+        $this->assertCount(1, $extension->reported);
+        $this->assertStringContainsString('backing service', $extension->reported[0]);
+    }
+
+    #[Test]
+    public function it_leaves_non_connection_failures_for_the_caller_to_rethrow(): void
+    {
+        $extension = $this->connectionFailureExtension();
+
+        // No-op (no throw) so the caller re-throws the original exception unchanged.
+        $extension->callFailIfBackingServiceUnavailable(new \RuntimeException('some unrelated seeding bug'));
+
+        $this->assertSame([], $extension->reported, 'Nothing should be reported for a non-connection failure');
+    }
+
+    #[Test]
+    public function guard_translates_a_refused_connection_thrown_by_the_pipeline(): void
+    {
+        $extension = $this->connectionFailureExtension();
+        $original = new \RuntimeException('Connection refused [tcp://127.0.0.1:6379]');
+
+        try {
+            $extension->callGuardBackingServices(function () use ($original) {
+                throw $original;
+            });
+            $this->fail('Expected the guard to re-throw');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('local stack must be running', $e->getMessage());
+            $this->assertSame($original, $e->getPrevious());
+        }
+
+        $this->assertCount(1, $extension->reported);
+    }
+
+    #[Test]
+    public function guard_rethrows_a_non_connection_failure_unchanged(): void
+    {
+        $extension = $this->connectionFailureExtension();
+        $original = new \RuntimeException('Undefined array key "sku"');
+
+        try {
+            $extension->callGuardBackingServices(function () use ($original) {
+                throw $original;
+            });
+            $this->fail('Expected the guard to re-throw');
+        } catch (\RuntimeException $e) {
+            // The exact original object must propagate, untranslated.
+            $this->assertSame($original, $e);
+        }
+
+        $this->assertSame([], $extension->reported);
+    }
+
+    #[Test]
+    public function guard_is_a_no_op_when_the_pipeline_succeeds(): void
+    {
+        $extension = $this->connectionFailureExtension();
+        $ran = false;
+
+        $extension->callGuardBackingServices(function () use (&$ran) {
+            $ran = true;
+        });
+
+        $this->assertTrue($ran, 'Pipeline should run');
+        $this->assertSame([], $extension->reported);
     }
 }


### PR DESCRIPTION
## Summary
- When the local stack is down, the `composer test-all` DB-setup step now aborts with a clear "backing service unavailable, start the local stack" message instead of a buried driver trace that reads as a database fault.
- `DBSetupExtension` wraps the migrate/seed pipeline: a refused connection (MySQL/Postgres via PDO, or Redis via predis/phpredis) is translated into a labeled `RuntimeException` and written to STDERR. A throw from a PHPUnit event subscriber is otherwise downgraded to a swallowed warning (the run continues), so the console write is the reliable signal, not a nicety.
- Real schema/data faults pass through unchanged; only "connection refused" is treated as a down-stack signal. The bare MySQL `[2002]` code is deliberately not matched, so a socket-path misconfiguration (`[2002] No such file or directory`) is not mislabeled as a stopped service.
- Extracts `guardBackingServices()` and `reportSetupFailure()` as small seams so the catch/translate/re-throw boundary is unit-testable without a bootstrapped application.

## Changes
- `src/Testing/DBSetupExtension.php`: wrap migrate/seed, add the refused-connection classifier + translation + console report.
- `tests/Unit/Testing/DBSetupExtensionTest.php`: classifier across drivers, previous-chain walk, non-connection pass-through, the translate/re-throw seam, and the console-write signal.

## Test plan
- [x] 22 DBSetupExtension unit tests pass (40 assertions)
- [x] Full suite green (645 passed; pre-existing PHPUnit deprecations/skips only)
- [x] Pint clean
- [x] External review: Codex + GLM-5.2 (fail-loud approach approved; regex narrowed, testable seams added, subscriber-swallow comment corrected per their findings)