### PR TITLE
ci: drop the Laravel 11 test matrix legs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,23 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ['8.3', '8.4']
-        laravel-version: ['11.*', '12.*']
+        laravel-version: ['12.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel-version: '11.*'
-            testbench-version: '9.*'
           - laravel-version: '12.*'
             testbench-version: '10.*'
-        exclude:
-          # Laravel 11's floor (11.0) pulls in Symfony 7.0, which predates PHP
-          # 8.4 and emits "implicit-nullable param" deprecations that Laravel's
-          # bootstrap converts to fatals before the test runner starts. Skip
-          # only that leg. Laravel 12's floor pulls Symfony 7.2 (8.4-clean), so
-          # it keeps prefer-lowest coverage on PHP 8.4. Both lines keep PHP 8.3
-          # floor coverage and PHP 8.4 prefer-stable coverage.
-          - php-version: '8.4'
-            laravel-version: '11.*'
-            dependency-version: prefer-lowest
 
     name: PHP ${{ matrix.php-version }} - Laravel ${{ matrix.laravel-version }} (${{ matrix.dependency-version }})
 

--- a/README.md
+++ b/README.md
@@ -329,10 +329,12 @@ If you do this on a host still running Laravel 10 or older (or PHPUnit 9), Compo
 
 ### Cross-Version Compatibility
 
-| Laravel | PHP | Monolog | Orchestra Testbench |
-|---------|-----|---------|---------------------|
-| 11.x   | 8.3+ | 3.x | 9.x |
-| 12.x   | 8.3+ | 3.x | 10.x |
+| Laravel | PHP | Monolog | Orchestra Testbench | CI coverage |
+|---------|-----|---------|---------------------|-------------|
+| 11.x   | 8.3+ | 3.x | 9.x | Not tested |
+| 12.x   | 8.3+ | 3.x | 10.x | PHP 8.3/8.4, prefer-lowest + prefer-stable |
+
+> **Laravel 11 has no CI coverage.** Composer's advisory database flags every installable `11.*` release, so the Laravel 11 matrix legs can no longer complete `composer update`. The `^11.0` floor stays, and the library carries no Laravel-12-only code, so Laravel 11 consumers keep receiving releases; changes are verified on the Laravel 12 legs only.
 
 > `laravel/framework` floor is `^11.0`. Laravel 10 reached end-of-life (security support ended February 2025) and was dropped in 0.7.0. The `ScheduleRunCommand::handle()` override declares a 4-arg signature (`Schedule, Dispatcher, Cache, ExceptionHandler`) that matches both the Laravel 11 and Laravel 12 parent, so the class loads cleanly on either line.
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "^8.3",
     "ext-gd": "*",
     "monolog/monolog": "^3.0",
-    "laravel/framework": "^11.0|^12.0",
+    "laravel/framework": "^12.0",
     "sentry/sentry-laravel": "^4.11",
     "guzzlehttp/guzzle": "^7.0",
     "swisnl/json-api-client": "^2.2",
@@ -32,7 +32,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5|^11.0|^12.0",
-    "orchestra/testbench": "^9.0|^10.0",
+    "orchestra/testbench": "^10.0",
     "laravel/pint": "^1.0",
     "mockery/mockery": "^1.6"
   },
@@ -55,7 +55,7 @@
     },
     "audit": {
       "ignore": {
-        "CVE-2026-48019": "CRLF injection in Laravel's default email rule. Fixed in 12.60+/13.10+; the upstream advisory (GHSA-5vg9-5847-vvmq) lists affected ranges as 12.x below 12.60 and 13.x up to 13.9 and does not list Laravel 11. Composer's advisory DB still flags our Laravel 11 floor, so `composer audit` reports it on both the L11 and the L12-below-12.60 legs; no 11.x patch is expected. Remove once resolved versions clear the advisory (L12 floored at 12.60+ and the L11 line dropped)."
+        "CVE-2026-48019": "CRLF injection in Laravel's default email rule (GHSA-5vg9-5847-vvmq). Fixed in 12.60+/13.10+; affected ranges are 12.x below 12.60 and 13.x up to 13.9. The Laravel floor stays at ^12.0 for consumer compatibility, so `composer audit` still flags the prefer-lowest L12-below-12.60 leg. Remove once the Laravel floor is raised to 12.60+."
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "^8.3",
     "ext-gd": "*",
     "monolog/monolog": "^3.0",
-    "laravel/framework": "^12.0",
+    "laravel/framework": "^11.0|^12.0",
     "sentry/sentry-laravel": "^4.11",
     "guzzlehttp/guzzle": "^7.0",
     "swisnl/json-api-client": "^2.2",
@@ -32,7 +32,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5|^11.0|^12.0",
-    "orchestra/testbench": "^10.0",
+    "orchestra/testbench": "^9.0|^10.0",
     "laravel/pint": "^1.0",
     "mockery/mockery": "^1.6"
   },
@@ -55,7 +55,7 @@
     },
     "audit": {
       "ignore": {
-        "CVE-2026-48019": "CRLF injection in Laravel's default email rule (GHSA-5vg9-5847-vvmq). Fixed in 12.60+/13.10+; affected ranges are 12.x below 12.60 and 13.x up to 13.9. The Laravel floor stays at ^12.0 for consumer compatibility, so `composer audit` still flags the prefer-lowest L12-below-12.60 leg. Remove once the Laravel floor is raised to 12.60+."
+        "CVE-2026-48019": "CRLF injection in Laravel's default email rule (GHSA-5vg9-5847-vvmq). Fixed in 12.60+/13.10+. The advisory's affected range is `<12.60.0`, so it covers the whole Laravel 11 line as well as 12.x below 12.60, and no 11.x patch is expected. Every test matrix leg pins Laravel 12, so `composer audit` reports this only on the prefer-lowest L12-below-12.60 leg. Remove once the Laravel floor is raised to 12.60+, which drops the 11.x line with it."
       }
     }
   }


### PR DESCRIPTION
## Summary
- The Laravel 11 CI legs can no longer complete `composer update`. Composer's advisory database flags every installable `11.*` release (`GHSA-5vg9-5847-vvmq`, affected range `<12.60.0`, no 11.x patch expected), so those legs fail before any test runs. This drops them, leaving PHP 8.3/8.4 x prefer-lowest/prefer-stable on Laravel 12.
- **The `laravel/framework: ^11.0|^12.0` floor is unchanged.** Narrowing it to `^12.0` would make every release cut afterwards unresolvable for consumers still on Laravel 11, and Composer reports that as a silently skipped version rather than an error, so those consumers would stop receiving library updates with no signal.
- The failing legs came from the matrix entries, not from the require constraint. Each test leg pins its own framework version with `composer require --no-update` before installing, and the unpinned `code-quality` job resolves to the highest compatible pair (Laravel 12), so a Laravel-12-only matrix keeps the advisory audit clean whatever the floor says.
- The README compatibility table gains a CI coverage column recording the split: Laravel 11 installable and free of Laravel-12-only code but unverified, Laravel 12 covered across both PHP versions and both dependency resolutions.

## Backwards compatibility
No change to installability. Laravel 11 consumers keep resolving and installing new releases, and the library carries no Laravel-12-only code. What changes is verification: Laravel 11 no longer has CI coverage, and that is now stated in the README instead of implied by a green matrix.

## Changes
- `.github/workflows/tests.yml`: matrix `laravel-version` `['11.*','12.*']` -> `['12.*']`; dropped the L11 testbench include and the PHP 8.4 prefer-lowest exclude that only existed to work around Laravel 11's Symfony 7.0 floor.
- `composer.json`: refreshed the `CVE-2026-48019` audit-ignore note to state the advisory's real affected range (`<12.60.0`, covering the whole 11.x line) and which leg still reports it. Requirements unchanged.
- `README.md`: CI coverage column on the compatibility table plus a note explaining why Laravel 11 is installable but untested.

```
 .github/workflows/tests.yml | 14 +-------------
 README.md                   | 10 ++++++----
 composer.json               |  2 +-
 3 files changed, 8 insertions(+), 18 deletions(-)
```

## Test plan
- [x] `composer validate` passes (composer.lock is gitignored; test jobs use `composer update`)
- [x] Full suite green locally on Laravel 12.62.0: 584 tests, 1911 assertions, 13 skipped
- [x] External review (Codex, repo-aware): 2 low findings, both applied
- [x] CI green: 4 Laravel 12 matrix legs + Code Quality
