### PR TITLE
feat(attachments): scan a whole upload in one engine invocation

### DIFF
--- a/docs/malware-scanning.md
+++ b/docs/malware-scanning.md
@@ -14,7 +14,7 @@ processAttachments()
        └─ clean                -> continue to resize (if opted in) and S3 upload
 ```
 
-- The scan runs on each file's upload tmp path via a `yr scan` subprocess (process isolation: a scanner crash cannot take the PHP worker down).
+- The whole upload is scanned in one `yr scan` subprocess (process isolation: a scanner crash cannot take the PHP worker down). See [How a batch is scanned](#how-a-batch-is-scanned) for why the unit is the request rather than the file.
 - One rule match on any file rejects the entire request, consistent with the service's all-or-nothing storage semantics.
 - Scan failures (binary missing, unreadable file, engine error, timeout, unparseable output) **fail closed** by default: the upload is rejected with HTTP 503 rather than stored unscanned.
 - For images that consumers resize (avatars/logos), the scan covers the raw original; the stored bytes are the re-encoded JPEG, which strips embedded payloads by construction. Non-images are stored exactly as scanned.
@@ -55,7 +55,7 @@ ATTACHMENTS_MALWARE_SCAN_ENABLED=true
 | `binary` | `ATTACHMENTS_MALWARE_SCAN_BINARY` | `yr` | YARA-X CLI binary: bare name (PATH) or absolute path. |
 | `rules_path` | `ATTACHMENTS_MALWARE_SCAN_RULES_PATH` | `null` | `.yar` file, directory of `.yar` files, or compiled `.yarc`. `null` uses the package baseline ruleset. Operator config only, never derive from request input. |
 | `compiled_rules` | `ATTACHMENTS_MALWARE_SCAN_COMPILED_RULES` | `false` | Set `true` when `rules_path` is a precompiled `.yarc` bundle. |
-| `timeout_seconds` | `ATTACHMENTS_MALWARE_SCAN_TIMEOUT` | `10` | Per-file scan timeout. A timeout is a scan failure, not a clean pass. |
+| `timeout_seconds` | `ATTACHMENTS_MALWARE_SCAN_TIMEOUT` | `10` | Timeout for the whole upload, which is scanned in one engine invocation. A timeout is a scan failure, not a clean pass. |
 | `fail_open` | `ATTACHMENTS_MALWARE_SCAN_FAIL_OPEN` | `false` | **Dangerous.** When true, scan *failures* log a warning and let the upload through instead of rejecting with 503. Detections always reject; `fail_open` never bypasses a match. |
 
 ## Exceptions
@@ -66,6 +66,43 @@ ATTACHMENTS_MALWARE_SCAN_ENABLED=true
 | `MalwareScanFailedException` | 503 | No trustworthy verdict (engine missing/broken/timeout). Retryable once the scanner is healthy. |
 
 Both extend `BaseHttpRequestException`, so services using `BaseErrorHandler` surface them consistently with no extra wiring. Services that catch-and-remap exceptions from `processAttachments()` should pass these two through untouched.
+
+## How a batch is scanned
+
+Every file in one upload goes to the engine in a **single invocation**. Ruleset load
+dominates scan cost (roughly a millisecond per rule, paid on every invocation and
+largely independent of file size), so scanning file by file multiplies the expensive
+part by the file count. With a real ruleset that is the difference between an upload
+that fits inside a gateway timeout and one that does not.
+
+`yr scan` takes exactly one target, so `YaraXScanner` stages the batch into a private
+directory and scans that directory once. Two properties of the staging are
+load-bearing:
+
+- **Hard links or copies, never symlinks.** A symlink inside a directory target is
+  skipped by the engine with no error, no stderr and no match, which reads back as a
+  clean verdict. Staging resolves each source path and verifies what landed (regular
+  file, matching size) rather than trusting the link call.
+- **The batch carries a canary.** A known-malicious file (the EICAR test string) is
+  staged alongside the real ones and matched back by its exact staged path. "No
+  matches" and "nothing was scanned" produce identical output, so if the canary does
+  not come back matched the batch is a scan failure, not a clean pass. This is what
+  catches a `rules_path` that points at a readable but wrong ruleset, the likeliest
+  fail-open in a deployment.
+
+What the canary does *not* prove is per-file coverage: it shows the engine ran this
+directory against a ruleset that can match something. Per-file coverage comes from
+staging every entry as a verified regular file, plus the any-stderr rule, since the
+engine does report a file it could not open. The silent skip is specific to symlinks.
+
+Two couplings worth stating:
+
+- The configured ruleset **must** detect EICAR, or every scan fails closed. The
+  baseline ruleset does, and a curated ruleset should be built with an EICAR
+  assertion at image build anyway.
+- Host antivirus that scans the system temp directory will quarantine the canary and
+  take every upload down with a 503. Exclude the `malware-scan-*` staging prefix
+  under `sys_get_temp_dir()` the same way you would exclude the ruleset directory.
 
 ## Rules
 
@@ -102,7 +139,18 @@ $this->app->bind(MalwareScanner::class, ClamAvScanner::class);
 new AttachmentService($disk, $model, $pivot, $fk, null, null, $scanner);
 ```
 
-Resolution order: constructor injection, then container binding, then `YaraXScanner` built from config. Implementations must throw `MalwareScanFailedException` whenever they cannot produce a trustworthy verdict; returning an empty match list means "definitely clean".
+The contract is a batch:
+
+```php
+/**
+ * @param  list<string>  $paths
+ * @return array<string, list<string>> Matched paths mapped to the rules they matched;
+ *                                     a clean path is absent from the result.
+ */
+public function scan(array $paths): array;
+```
+
+Resolution order: constructor injection, then container binding, then `YaraXScanner` built from config. Implementations must throw `MalwareScanFailedException` whenever they cannot produce a trustworthy verdict **for every path in the batch**; an empty result means every file is definitely clean, never that some went unscanned.
 
 ## Testing
 
@@ -119,7 +167,8 @@ $service = new AttachmentService($disk, $model, $pivot, $fk, null, null, $scanne
 // FakeMalwareScanner::clean()      — everything passes
 // FakeMalwareScanner::detecting()  — everything matches
 // FakeMalwareScanner::failing()    — every scan throws (engine outage)
-// $scanner->scannedPaths           — records every scanned path
+// $scanner->scannedPaths           — every scanned path, flattened
+// $scanner->batches                — one entry per scan() call, to assert a single invocation
 ```
 
 The package's own integration test runs the real binary when available:
@@ -130,7 +179,8 @@ YARA_X_BINARY=/path/to/yr vendor/bin/phpunit --filter YaraXScannerIntegrationTes
 
 ## Operational notes
 
-- **Latency**: one subprocess per uploaded file, typically a few tens of milliseconds with the baseline ruleset. Large rulesets benefit from `.yarc` precompilation.
-- **Resource abuse**: scanning is CPU-bound and per-file. Upload size limits and request rate limiting remain the consuming service's responsibility; `timeout_seconds` bounds each scan.
+- **Latency**: one subprocess per upload, not per file. Cost is dominated by ruleset load, so it scales with rule count rather than file count: the baseline ruleset is a few tens of milliseconds, and a several-thousand-rule curated set costs seconds. Precompile large rulesets to `.yarc` (roughly 10x faster to load than `.yar` source) and size `timeout_seconds` against the container's actual CPU share, which is usually a fraction of a core.
+- **Resource abuse**: scanning is CPU-bound. Upload size limits and request rate limiting remain the consuming service's responsibility; `timeout_seconds` bounds the whole batch.
+- **Disk**: staging hard-links where it can, so the batch normally costs directory entries rather than bytes. It falls back to copying when the upload's temp directory is on a different filesystem from `sys_get_temp_dir()`, which needs headroom for one extra copy of the upload.
 - **Monitoring**: every detection logs a warning with the matched rule ids; scan failures log errors (fail closed) or warnings (`fail_open`). Alert on both.
 - **Host AV/EDR**: `resources/malware-rules/eicar.yar` contains the EICAR signature in source form; some endpoint-protection tools quarantine files containing it on checkout. Exclude the vendor path from host scanning, or point `rules_path` at your own ruleset and drop the baseline.

--- a/src/Contracts/MalwareScanner.php
+++ b/src/Contracts/MalwareScanner.php
@@ -5,20 +5,29 @@ namespace NuiMarkets\LaravelSharedUtils\Contracts;
 use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
 
 /**
- * Scans a file on local disk for malware.
+ * Scans files on local disk for malware.
+ *
+ * The unit is a batch, not a file, because ruleset load dominates scan cost:
+ * a real ruleset costs the same to load whether it then scans one file or ten,
+ * so a per-file call multiplies the expensive part by the file count and puts a
+ * multi-file upload over the API gateway timeout.
  *
  * Implementations must fail loudly: any condition that prevents a trustworthy
- * verdict (missing engine, unreadable file, engine error, timeout) throws
- * MalwareScanFailedException rather than returning an empty match list.
+ * verdict for *every* path in the batch (missing engine, unreadable file, engine
+ * error, timeout, a file the engine declined to open) throws
+ * MalwareScanFailedException. An empty result means every path scanned clean,
+ * never that some of them went unscanned.
  */
 interface MalwareScanner
 {
     /**
-     * Scan the file at $path.
+     * Scan every path in one pass.
      *
-     * @return list<string> Identifiers of matched malware rules; an empty list means clean.
+     * @param  list<string>  $paths  Paths to regular, readable files on local disk
+     * @return array<string, list<string>> Matched paths mapped to the rule identifiers they matched.
+     *                                     A path that scanned clean is absent from the result.
      *
-     * @throws MalwareScanFailedException when no trustworthy verdict could be produced
+     * @throws MalwareScanFailedException when no trustworthy verdict could be produced for the batch
      */
-    public function scan(string $path): array;
+    public function scan(array $paths): array;
 }

--- a/src/Services/AttachmentService.php
+++ b/src/Services/AttachmentService.php
@@ -467,6 +467,11 @@ class AttachmentService
      * `attachments.malware_scan.enabled` is true, so the scanner is never even
      * resolved for consumers that haven't opted in.
      *
+     * The whole upload goes to the scanner as a single batch. Ruleset load
+     * dominates scan cost, so scanning file by file multiplies the expensive
+     * part by the file count and puts a multi-file upload over the gateway
+     * timeout; one batch pays that cost once.
+     *
      * Scan failures (engine missing/broken/timeout) reject the request too
      * (fail closed) unless `fail_open` is set, which logs and continues.
      * Detections always reject; fail_open never bypasses a match.
@@ -484,56 +489,119 @@ class AttachmentService
 
         $failOpen = (bool) config('attachments.malware_scan.fail_open', false);
 
+        // Keyed by path, in upload order, so which file a rejection names stays
+        // deterministic however the engine happens to order its matches.
+        $targets = [];
+
         foreach ($files as $file) {
             if (! $file instanceof UploadedFile) {
                 continue;
             }
 
             $filename = $file->getClientOriginalName();
+            $path = $file->getRealPath();
 
-            try {
-                $path = $file->getRealPath();
-                if ($path === false || ! is_file($path)) {
-                    throw new MalwareScanFailedException('Upload tmp file is not readable for malware scan.');
-                }
-
-                $matches = $this->malwareScanner()->scan($path);
-            } catch (Throwable $e) {
-                // Custom scanner backends may throw anything; normalize so the
-                // fail-closed / fail_open semantics hold for every failure
-                // shape instead of leaking a generic 500.
-                if (! $e instanceof MalwareScanFailedException) {
-                    $e = new MalwareScanFailedException('Malware scanner threw an unexpected error.', $e);
-                }
-
-                if (! $failOpen) {
-                    Log::error('Malware scan failed - rejecting upload (fail closed)', [
-                        'file_name' => $filename,
-                        'error' => $e->getMessage(),
-                        'extra' => $e->getExtra(),
-                        'exception' => $e,
-                    ]);
-                    throw $e;
-                }
-
-                Log::warning('Malware scan failed - allowing upload (fail_open enabled)', [
-                    'file_name' => $filename,
-                    'error' => $e->getMessage(),
-                    'extra' => $e->getExtra(),
-                    'exception' => $e,
-                ]);
+            if ($path === false || ! is_file($path)) {
+                $this->handleScanFailure(
+                    new MalwareScanFailedException('Upload tmp file is not readable for malware scan.'),
+                    [$filename],
+                    $failOpen,
+                );
 
                 continue;
             }
 
-            if ($matches !== []) {
-                Log::warning('Malware detected in upload - rejecting request', [
-                    'file_name' => $filename,
-                    'matched_rules' => $matches,
-                ]);
-                throw new MalwareDetectedException($filename, $matches);
+            $targets[$path] = $filename;
+        }
+
+        if ($targets === []) {
+            return;
+        }
+
+        try {
+            $matches = $this->malwareScanner()->scan(array_keys($targets));
+        } catch (Throwable $e) {
+            // Custom scanner backends may throw anything; normalize so the
+            // fail-closed / fail_open semantics hold for every failure
+            // shape instead of leaking a generic 500.
+            if (! $e instanceof MalwareScanFailedException) {
+                $e = new MalwareScanFailedException('Malware scanner threw an unexpected error.', $e);
+            }
+
+            $this->handleScanFailure($e, array_values($targets), $failOpen);
+
+            return;
+        }
+
+        // A verdict about a file we did not submit is not a verdict about the
+        // ones we did. Dropping it would turn a detection from a custom backend
+        // into a clean upload, so it fails the scan instead.
+        $unknown = array_diff(array_keys($matches), array_keys($targets));
+
+        if ($unknown !== []) {
+            $this->handleScanFailure(
+                new MalwareScanFailedException('Malware scanner reported a verdict for a file it was not given.', null, [
+                    'unexpected_files' => array_values($unknown),
+                ]),
+                array_values($targets),
+                $failOpen,
+            );
+
+            return;
+        }
+
+        // Keyed by path, so two uploads sharing a client filename cannot
+        // overwrite each other's rules.
+        $detected = [];
+
+        foreach ($targets as $path => $filename) {
+            if (! empty($matches[$path])) {
+                $detected[$path] = $filename;
             }
         }
+
+        if ($detected === []) {
+            return;
+        }
+
+        $path = (string) array_key_first($detected);
+        $filename = $detected[$path];
+        $rules = $matches[$path];
+
+        Log::warning('Malware detected in upload - rejecting request', [
+            'file_name' => $filename,
+            'matched_rules' => $rules,
+            'detected_file_names' => array_values($detected),
+        ]);
+
+        throw new MalwareDetectedException($filename, $rules);
+    }
+
+    /**
+     * Reject the upload, or log and let it through when `fail_open` is set.
+     * Only ever reached for a scan *failure*; a detection always rejects.
+     *
+     * @param  list<string>  $filenames  The uploads this failure covers
+     *
+     * @throws MalwareScanFailedException when failing closed
+     */
+    private function handleScanFailure(MalwareScanFailedException $e, array $filenames, bool $failOpen): void
+    {
+        $context = [
+            'file_name' => $filenames[0] ?? null,
+            'file_names' => $filenames,
+            'error' => $e->getMessage(),
+            'extra' => $e->getExtra(),
+            'exception' => $e,
+        ];
+
+        if (! $failOpen) {
+            Log::error('Malware scan failed - rejecting upload (fail closed)', $context);
+
+            throw $e;
+        }
+
+        Log::warning('Malware scan failed - allowing upload (fail_open enabled)', $context);
     }
 
     /**

--- a/src/Services/YaraXScanner.php
+++ b/src/Services/YaraXScanner.php
@@ -2,6 +2,7 @@
 
 namespace NuiMarkets\LaravelSharedUtils\Services;
 
+use Illuminate\Support\Facades\Log;
 use JsonException;
 use NuiMarkets\LaravelSharedUtils\Contracts\MalwareScanner;
 use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
@@ -14,13 +15,22 @@ use Throwable;
  * process so a scanner crash can never take the PHP worker down.
  *
  * CLI contract (verified against yara-x 1.19.0):
- *  - `yr scan --output-format=json <rules> <file>` prints a single JSON object
+ *  - `yr scan --output-format=json <rules> <target>` prints a single JSON object
  *    `{"version": "...", "matches": [{"rule": "...", "file": "..."}]}`.
  *  - Exit code 0 for BOTH match and clean; the verdict is only in `matches`.
- *  - An unreadable/missing TARGET file also exits 0 with empty matches and the
- *    error on stderr only — parsing stdout alone would silently fail open, so
- *    any stderr output fails the scan.
+ *  - An unreadable/missing TARGET also exits 0 with empty matches and the error
+ *    on stderr only — parsing stdout alone would silently fail open, so any
+ *    stderr output fails the scan.
  *  - A missing/invalid RULES path exits non-zero.
+ *  - `scan` takes exactly one TARGET, which may be a directory. A directory
+ *    target scans the files directly inside it, reporting each match with its
+ *    absolute path. That is how a batch is scanned in one ruleset load.
+ *  - A symlink inside a directory target is SKIPPED, silently, with no stderr
+ *    and no match — a fail-open path in a fail-closed control. Batch staging
+ *    therefore hard-links or copies, never symlinks, and verifies what landed.
+ *  - An *unreadable regular* file inside a directory target is different: it is
+ *    skipped but reported on stderr, so the any-stderr rule already fails that
+ *    batch. The symlink case is the only silent skip found.
  */
 class YaraXScanner implements MalwareScanner
 {
@@ -29,6 +39,20 @@ class YaraXScanner implements MalwareScanner
      * misbehaving scanner can't flood logs or Sentry payloads.
      */
     private const OUTPUT_CAP = 1000;
+
+    /**
+     * Name of the known-malicious file staged alongside every batch. The engine
+     * reporting no matches is indistinguishable from the engine having scanned
+     * nothing, so the batch carries its own positive control: if the canary
+     * doesn't come back matched, the verdict on the real files is not trusted.
+     *
+     * It proves the engine ran this directory against a ruleset that can match
+     * something, which is what catches a rules_path pointing at the wrong file.
+     * It does not prove per-file coverage; that comes from staging every entry
+     * as a verified regular file, and from any skip the engine does report
+     * landing on stderr.
+     */
+    public const CANARY_NAME = 'zz-scan-canary';
 
     public function __construct(
         protected string $binary,
@@ -72,10 +96,31 @@ class YaraXScanner implements MalwareScanner
         return dirname(__DIR__, 2).'/resources/malware-rules';
     }
 
-    public function scan(string $path): array
+    /**
+     * The EICAR test string, assembled at runtime so the package artifact
+     * itself doesn't carry a literal antivirus trigger.
+     */
+    public static function canaryContent(): string
     {
-        if (! is_file($path) || ! is_readable($path)) {
-            throw new MalwareScanFailedException('Malware scan target is not readable.');
+        return 'X5O!P%@AP[4\PZX54(P^)7CC)7}$'.'EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*';
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return array<string, list<string>>
+     */
+    public function scan(array $paths): array
+    {
+        $paths = array_values($paths);
+
+        if ($paths === []) {
+            return [];
+        }
+
+        foreach ($paths as $path) {
+            if (! is_file($path) || ! is_readable($path)) {
+                throw new MalwareScanFailedException('Malware scan target is not readable.');
+            }
         }
 
         if (! file_exists($this->rulesPath) || ! is_readable($this->rulesPath)) {
@@ -84,13 +129,112 @@ class YaraXScanner implements MalwareScanner
             ]);
         }
 
+        [$dir, $staged] = $this->stageBatch($paths);
+
+        try {
+            return $this->mapMatches($this->runEngine($dir), $staged, $dir.'/'.self::CANARY_NAME);
+        } finally {
+            $this->removeBatch($dir);
+        }
+    }
+
+    /**
+     * Assemble the batch in a private directory the engine can scan in one pass.
+     *
+     * Hard-links where the filesystem allows it and copies otherwise, because a
+     * symlinked entry is skipped by the engine without any error and would read
+     * back as clean.
+     *
+     * @param  list<string>  $paths
+     * @return array{0: string, 1: array<string, string>} Staging directory, and staged path => source path
+     */
+    protected function stageBatch(array $paths): array
+    {
+        $dir = sys_get_temp_dir().'/malware-scan-'.bin2hex(random_bytes(8));
+
+        if (! @mkdir($dir, 0700) && ! is_dir($dir)) {
+            throw new MalwareScanFailedException('Could not create the malware scan staging directory.');
+        }
+
+        // Canonicalise once, so the paths the engine echoes back can be matched
+        // exactly rather than by basename, whatever the temp directory resolves
+        // through.
+        $dir = realpath($dir) ?: $dir;
+
+        $staged = [];
+
+        try {
+            foreach ($paths as $i => $path) {
+                $target = $dir.'/f'.$i;
+
+                // Link from the resolved path: link() does not follow symlinks,
+                // so a symlinked source would otherwise stage as a symlink and
+                // be skipped by the engine.
+                $source = realpath($path);
+
+                if ($source === false) {
+                    throw new MalwareScanFailedException('Malware scan target is not readable.');
+                }
+
+                if (! @link($source, $target) && ! @copy($source, $target)) {
+                    throw new MalwareScanFailedException('Could not stage an upload for the malware scan.');
+                }
+
+                // Verify what landed rather than trusting the staging call: an
+                // entry the engine would skip must fail the scan, not pass it.
+                clearstatcache(true, $target);
+                if (is_link($target) || ! is_file($target) || filesize($target) !== filesize($path)) {
+                    throw new MalwareScanFailedException('A staged malware scan target did not match its source.');
+                }
+
+                $staged[$target] = $path;
+            }
+
+            $canary = self::canaryContent();
+
+            if (file_put_contents($dir.'/'.self::CANARY_NAME, $canary) !== strlen($canary)) {
+                throw new MalwareScanFailedException('Could not stage the malware scan canary.');
+            }
+        } catch (Throwable $e) {
+            $this->removeBatch($dir);
+            throw $e;
+        }
+
+        return [$dir, $staged];
+    }
+
+    /**
+     * Remove the staging directory. A leak here would accumulate copies of
+     * uploaded files and a live EICAR sample under the temp directory, so it is
+     * reported rather than swallowed, even though it cannot change the verdict.
+     */
+    protected function removeBatch(string $dir): void
+    {
+        // Not glob(), which skips dotfiles and would leave the directory
+        // undeletable without saying so.
+        foreach (array_diff(scandir($dir) ?: [], ['.', '..']) as $entry) {
+            @unlink($dir.'/'.$entry);
+        }
+
+        if (! @rmdir($dir) && is_dir($dir)) {
+            Log::warning('Could not remove the malware scan staging directory', [
+                'directory' => $dir,
+            ]);
+        }
+    }
+
+    /**
+     * Run one engine invocation over the whole staging directory.
+     */
+    protected function runEngine(string $dir): string
+    {
         $command = [$this->binary, 'scan', '--output-format=json', '--disable-warnings'];
         if ($this->compiledRules) {
             $command[] = '--compiled-rules';
         }
         $command[] = '--';
         $command[] = $this->rulesPath;
-        $command[] = $path;
+        $command[] = $dir;
 
         $process = new Process($command);
         $process->setTimeout($this->timeoutSeconds);
@@ -117,7 +261,7 @@ class YaraXScanner implements MalwareScanner
             ]);
         }
 
-        return $this->parseMatches($process->getOutput());
+        return $process->getOutput();
     }
 
     /**
@@ -130,13 +274,16 @@ class YaraXScanner implements MalwareScanner
     }
 
     /**
-     * Parse matched rule identifiers out of the engine's JSON stdout. Strict:
-     * anything other than a well-formed `matches` list of `{rule: string}`
-     * entries is a scan failure, never a clean verdict.
+     * Turn the engine's JSON stdout into source path => matched rules. Strict:
+     * anything other than a well-formed `matches` list of `{rule, file}` entries
+     * is a scan failure, never a clean verdict, and so is a batch whose canary
+     * went unmatched or which reports a file that was never staged.
      *
-     * @return list<string>
+     * @param  array<string, string>  $staged  Staged path => source path
+     * @param  string  $canaryPath  Staged path of the canary
+     * @return array<string, list<string>>
      */
-    protected function parseMatches(string $stdout): array
+    protected function mapMatches(string $stdout, array $staged, string $canaryPath): array
     {
         try {
             $decoded = json_decode($stdout, true, flags: JSON_THROW_ON_ERROR);
@@ -152,20 +299,46 @@ class YaraXScanner implements MalwareScanner
             ]);
         }
 
-        $rules = [];
+        $byPath = [];
 
         foreach ($decoded['matches'] as $match) {
             $rule = is_array($match) ? ($match['rule'] ?? null) : null;
+            $file = is_array($match) ? ($match['file'] ?? null) : null;
 
-            if (! is_string($rule) || $rule === '') {
+            if (! is_string($rule) || $rule === '' || ! is_string($file) || $file === '') {
                 throw new MalwareScanFailedException('Malware scan output contained a malformed match entry.', null, [
                     'stdout' => $this->capOutput($stdout),
                 ]);
             }
 
-            $rules[] = $rule;
+            $byPath[$file][] = $rule;
         }
 
-        return array_values(array_unique($rules));
+        // Matched by exact staged path, not basename: the canary's authority
+        // comes from being the file this invocation planted in this directory,
+        // and a same-named file anywhere else must not stand in for it.
+        if (! isset($byPath[$canaryPath])) {
+            throw new MalwareScanFailedException(
+                'Malware scan did not flag its own canary, so the ruleset did not cover the batch.',
+                null,
+                ['rules_path' => $this->rulesPath],
+            );
+        }
+
+        unset($byPath[$canaryPath]);
+
+        $results = [];
+
+        foreach ($byPath as $path => $rules) {
+            if (! isset($staged[$path])) {
+                throw new MalwareScanFailedException('Malware scan reported a match on a file it was not given.', null, [
+                    'file' => $path,
+                ]);
+            }
+
+            $results[$staged[$path]] = array_values(array_unique($rules));
+        }
+
+        return $results;
     }
 }

--- a/src/Testing/FakeMalwareScanner.php
+++ b/src/Testing/FakeMalwareScanner.php
@@ -14,16 +14,20 @@ use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
  *   $scanner = FakeMalwareScanner::detectingContent('EICAR', ['Eicar_Rule']);
  *   $scanner = FakeMalwareScanner::failing('Simulated engine outage');
  *
- * Every scanned path is recorded in $scannedPaths for ordering/coverage
- * assertions.
+ * Every scanned path is recorded in $scannedPaths for coverage assertions, and
+ * every call is recorded in $batches, so a test can pin that an upload reached
+ * the engine as one batch rather than one invocation per file.
  */
 class FakeMalwareScanner implements MalwareScanner
 {
     /** @var callable(string): list<string> */
     private $verdict;
 
-    /** @var list<string> Paths passed to scan(), in call order. */
+    /** @var list<string> Every path passed to scan(), flattened, in call order. */
     public array $scannedPaths = [];
+
+    /** @var list<list<string>> One entry per scan() call, holding that call's paths. */
+    public array $batches = [];
 
     private function __construct(callable $verdict)
     {
@@ -58,10 +62,28 @@ class FakeMalwareScanner implements MalwareScanner
         });
     }
 
-    public function scan(string $path): array
+    /**
+     * @param  list<string>  $paths
+     * @return array<string, list<string>>
+     */
+    public function scan(array $paths): array
     {
-        $this->scannedPaths[] = $path;
+        $paths = array_values($paths);
 
-        return ($this->verdict)($path);
+        $this->batches[] = $paths;
+
+        $matches = [];
+
+        foreach ($paths as $path) {
+            $this->scannedPaths[] = $path;
+
+            $rules = ($this->verdict)($path);
+
+            if ($rules !== []) {
+                $matches[$path] = array_values($rules);
+            }
+        }
+
+        return $matches;
     }
 }

--- a/tests/Feature/YaraXScannerIntegrationTest.php
+++ b/tests/Feature/YaraXScannerIntegrationTest.php
@@ -69,43 +69,109 @@ class YaraXScannerIntegrationTest extends TestCase
         return 'X5O!P%@AP[4\PZX54(P^)7CC)7}$'.'EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*';
     }
 
+    private function write(string $name, string $content): string
+    {
+        $path = $this->tmpDir.'/'.$name;
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
     public function test_detects_eicar_with_baseline_rules()
     {
-        $path = $this->tmpDir.'/eicar.pdf';
-        file_put_contents($path, $this->eicarContent());
+        $path = $this->write('eicar.pdf', $this->eicarContent());
 
-        $matches = $this->scanner()->scan($path);
-
-        $this->assertContains('EICAR_Test_File', $matches);
+        $this->assertContains('EICAR_Test_File', $this->scanner()->scan([$path])[$path] ?? []);
     }
 
     public function test_detects_obfuscated_php_eval_with_baseline_rules()
     {
-        $path = $this->tmpDir.'/upload.pdf';
-        file_put_contents($path, '<?php eval(base64_decode("cGhwaW5mbygpOw==")); ?>');
+        $path = $this->write('upload.pdf', '<?php eval(base64_decode("cGhwaW5mbygpOw==")); ?>');
 
-        $matches = $this->scanner()->scan($path);
-
-        $this->assertContains('PHP_Webshell_Obfuscated_Eval', $matches);
+        $this->assertContains('PHP_Webshell_Obfuscated_Eval', $this->scanner()->scan([$path])[$path] ?? []);
     }
 
     public function test_clean_file_returns_no_matches()
     {
-        $path = $this->tmpDir.'/clean.txt';
-        file_put_contents($path, 'perfectly ordinary document content');
+        $path = $this->write('clean.txt', 'perfectly ordinary document content');
 
-        $this->assertSame([], $this->scanner()->scan($path));
+        $this->assertSame([], $this->scanner()->scan([$path]));
+    }
+
+    public function test_batch_attributes_each_match_to_its_own_file()
+    {
+        $clean = $this->write('clean.txt', 'perfectly ordinary document content');
+        $eicar = $this->write('eicar.pdf', $this->eicarContent());
+        $shell = $this->write('shell.pdf', '<?php eval(base64_decode("cGhwaW5mbygpOw==")); ?>');
+
+        $matches = $this->scanner()->scan([$clean, $eicar, $shell]);
+
+        $this->assertArrayNotHasKey($clean, $matches);
+        $this->assertContains('EICAR_Test_File', $matches[$eicar]);
+        $this->assertContains('PHP_Webshell_Obfuscated_Eval', $matches[$shell]);
+    }
+
+    public function test_symlinked_source_is_still_scanned()
+    {
+        // A symlink inside a directory target is skipped by the engine with no
+        // error and no match. Staging dereferences it, so a caller handing us
+        // one still gets a real verdict rather than a false clean.
+        $real = $this->write('eicar.pdf', $this->eicarContent());
+        $link = $this->tmpDir.'/link.pdf';
+        symlink($real, $link);
+
+        $this->assertContains('EICAR_Test_File', $this->scanner()->scan([$link])[$link] ?? []);
+    }
+
+    public function test_engine_still_skips_symlinks_in_a_directory_target()
+    {
+        // Pins the upstream behavior the staging strategy exists for. If a
+        // future YARA-X follows symlinks, this fails and the hard-link
+        // requirement can be revisited rather than cargo-culted.
+        $dir = $this->tmpDir.'/target';
+        mkdir($dir);
+        $real = $this->write('eicar-src.pdf', $this->eicarContent());
+        symlink($real, $dir.'/linked.pdf');
+
+        $process = new Process([
+            $this->binary, 'scan', '--output-format=json', '--disable-warnings',
+            '--', YaraXScanner::defaultRulesPath(), $dir,
+        ]);
+        $process->run();
+
+        try {
+            $this->assertSame(0, $process->getExitCode());
+            $this->assertSame('', trim($process->getErrorOutput()), 'Engine reported nothing on stderr');
+            $this->assertSame([], json_decode($process->getOutput(), true)['matches']);
+        } finally {
+            @unlink($dir.'/linked.pdf');
+            @rmdir($dir);
+        }
+    }
+
+    public function test_ruleset_that_cannot_catch_the_canary_is_a_scan_failure()
+    {
+        // The likeliest fail-open in deployment is rules_path pointing at a
+        // readable but wrong ruleset: every scan would come back clean. The
+        // canary turns that into a loud 503.
+        $rules = $this->write('narrow.yar', 'rule Never_Matches { strings: $a = "zzz-not-in-any-test-file-zzz" condition: $a }');
+        $path = $this->write('eicar.pdf', $this->eicarContent());
+
+        $scanner = new YaraXScanner($this->binary, $rules);
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->expectExceptionMessage('canary');
+        $scanner->scan([$path]);
     }
 
     public function test_real_binary_with_bad_rules_path_is_scan_failure()
     {
-        $path = $this->tmpDir.'/clean.txt';
-        file_put_contents($path, 'content');
+        $path = $this->write('clean.txt', 'content');
 
         $scanner = new YaraXScanner($this->binary, $this->tmpDir.'/missing-rules');
 
         $this->expectException(MalwareScanFailedException::class);
-        $scanner->scan($path);
+        $scanner->scan([$path]);
     }
 
     public function test_real_binary_with_unreadable_target_is_scan_failure()
@@ -114,13 +180,12 @@ class YaraXScannerIntegrationTest extends TestCase
             $this->markTestSkipped('root can read anything; permission check not testable');
         }
 
-        $path = $this->tmpDir.'/eicar.pdf';
-        file_put_contents($path, $this->eicarContent());
+        $path = $this->write('eicar.pdf', $this->eicarContent());
         chmod($path, 0000);
 
         try {
             $this->expectException(MalwareScanFailedException::class);
-            $this->scanner()->scan($path);
+            $this->scanner()->scan([$path]);
         } finally {
             chmod($path, 0644);
         }
@@ -134,11 +199,10 @@ class YaraXScannerIntegrationTest extends TestCase
         ]);
         $compile->mustRun();
 
-        $path = $this->tmpDir.'/eicar.pdf';
-        file_put_contents($path, $this->eicarContent());
+        $path = $this->write('eicar.pdf', $this->eicarContent());
 
         $scanner = new YaraXScanner($this->binary, $compiled, compiledRules: true);
 
-        $this->assertContains('EICAR_Test_File', $scanner->scan($path));
+        $this->assertContains('EICAR_Test_File', $scanner->scan([$path])[$path] ?? []);
     }
 }

--- a/tests/Unit/Services/AttachmentServiceMalwareScanTest.php
+++ b/tests/Unit/Services/AttachmentServiceMalwareScanTest.php
@@ -157,6 +157,53 @@ class AttachmentServiceMalwareScanTest extends TestCase
         }
     }
 
+    public function test_multi_file_upload_reaches_the_scanner_as_one_batch()
+    {
+        // Ruleset load dominates scan cost, so a per-file call multiplies the
+        // expensive part by the file count and puts a full upload over the
+        // gateway timeout. One invocation for the whole request, always.
+        $this->enableScan();
+        $scanner = FakeMalwareScanner::clean();
+        $service = $this->makeService($scanner);
+
+        $files = [];
+        for ($i = 0; $i < 10; $i++) {
+            $files[] = UploadedFile::fake()->createWithContent("file{$i}.pdf", "content {$i}");
+        }
+
+        $service->processAttachments($this->makeEntity(), $files);
+
+        $this->assertCount(1, $scanner->batches, 'Expected exactly one scanner invocation');
+        $this->assertCount(10, $scanner->batches[0]);
+    }
+
+    public function test_detection_names_the_first_infected_file_in_upload_order()
+    {
+        // The engine reports matches in whatever order it finds them, so the
+        // file a rejection names must come from the upload order instead.
+        $this->enableScan();
+        $service = $this->makeService(FakeMalwareScanner::detectingContent(self::INFECTED_MARKER, ['Fake_Rule']));
+
+        $files = [
+            UploadedFile::fake()->createWithContent('clean.pdf', 'harmless'),
+            UploadedFile::fake()->createWithContent('first-bad.pdf', 'payload '.self::INFECTED_MARKER),
+            UploadedFile::fake()->createWithContent('second-bad.pdf', 'payload '.self::INFECTED_MARKER),
+        ];
+
+        $thrown = null;
+
+        try {
+            $service->processAttachments($this->makeEntity(), $files);
+        } catch (MalwareDetectedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown);
+        $this->assertStringContainsString('first-bad.pdf', $thrown->getMessage());
+        $this->assertStringNotContainsString('second-bad.pdf', $thrown->getMessage());
+        $this->assertNothingStored();
+    }
+
     public function test_scan_failure_rejects_request_by_default()
     {
         $this->enableScan();
@@ -222,11 +269,102 @@ class AttachmentServiceMalwareScanTest extends TestCase
         $this->assertCount(1, $attachments);
     }
 
+    public function test_verdict_for_a_file_we_did_not_submit_fails_closed()
+    {
+        // A backend reporting on something we never handed it is not reporting
+        // on what we did hand it. Ignoring the stray entry would turn a
+        // detection into a stored upload.
+        $this->enableScan();
+
+        $scanner = new class implements MalwareScanner
+        {
+            public function scan(array $paths): array
+            {
+                return ['/some/other/file' => ['Malware_Rule']];
+            }
+        };
+
+        $thrown = null;
+
+        try {
+            $this->makeService($scanner)->processAttachments($this->makeEntity(), UploadedFile::fake()->image('clean.jpg'));
+        } catch (MalwareScanFailedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'Expected a scan failure, not a clean upload');
+        $this->assertSame(503, $thrown->getStatusCode());
+        $this->assertNothingStored();
+    }
+
+    public function test_duplicate_client_filenames_keep_their_own_matched_rules()
+    {
+        // Two uploads can share a client filename. Keying results by name would
+        // let one overwrite the other and report the wrong rules for the file
+        // it names.
+        $this->enableScan();
+
+        $files = [
+            UploadedFile::fake()->createWithContent('report.pdf', 'first payload'),
+            UploadedFile::fake()->createWithContent('report.pdf', 'second payload'),
+        ];
+        $firstPath = $files[0]->getRealPath();
+
+        $scanner = new class($firstPath) implements MalwareScanner
+        {
+            public function __construct(private string $firstPath) {}
+
+            public function scan(array $paths): array
+            {
+                $matches = [];
+
+                foreach ($paths as $path) {
+                    $matches[$path] = $path === $this->firstPath ? ['First_Rule'] : ['Second_Rule'];
+                }
+
+                return $matches;
+            }
+        };
+
+        $thrown = null;
+
+        try {
+            $this->makeService($scanner)->processAttachments($this->makeEntity(), $files);
+        } catch (MalwareDetectedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown);
+        $this->assertSame(['First_Rule'], $thrown->getMatchedRules());
+        $this->assertNothingStored();
+    }
+
+    public function test_unreadable_tmp_file_fails_the_request_by_default()
+    {
+        $this->enableScan();
+        $scanner = FakeMalwareScanner::clean();
+
+        $file = UploadedFile::fake()->createWithContent('gone.pdf', 'content');
+        unlink($file->getRealPath());
+
+        $thrown = null;
+
+        try {
+            $this->makeService($scanner)->processAttachments($this->makeEntity(), [$file]);
+        } catch (MalwareScanFailedException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown, 'Expected fail closed on an unreadable upload tmp file');
+        $this->assertSame([], $scanner->batches, 'Scanner should not run for an unreadable file');
+        $this->assertNothingStored();
+    }
+
     private function throwingScanner(): MalwareScanner
     {
         return new class implements MalwareScanner
         {
-            public function scan(string $path): array
+            public function scan(array $paths): array
             {
                 throw new \RuntimeException('unexpected backend explosion');
             }

--- a/tests/Unit/Services/YaraXScannerTest.php
+++ b/tests/Unit/Services/YaraXScannerTest.php
@@ -11,6 +11,10 @@ use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
  * standing in for the yr binary), so the suite never needs YARA-X installed.
  * The real-binary contract is covered by the opt-in
  * Feature\YaraXScannerIntegrationTest.
+ *
+ * The scanner stages a batch into a private directory and hands the engine that
+ * one directory, so a stub sees staged names (`f0`, `f1`, ...) plus the canary,
+ * never the caller's paths.
  */
 class YaraXScannerTest extends TestCase
 {
@@ -56,38 +60,241 @@ class YaraXScannerTest extends TestCase
         return $path;
     }
 
+    /**
+     * A stub that prints a well-formed match list. Matches are reported against
+     * the staging directory the scanner actually passed it (its last argument),
+     * because the scanner attributes by exact path.
+     *
+     * The canary match is included by default, since a batch without it is a
+     * scan failure by design; pass false to simulate an engine that scanned
+     * nothing. Pass a name starting with '/' to report an absolute path outside
+     * the staging directory.
+     *
+     * @param  list<array{0: string, 1: string}>  $matches  [rule, staged name] pairs
+     */
+    private function matchingStub(array $matches = [], bool $withCanary = true): string
+    {
+        $entries = $withCanary
+            ? array_merge([['Canary_Rule', YaraXScanner::CANARY_NAME]], $matches)
+            : $matches;
+
+        $parts = [];
+        $args = [];
+
+        foreach ($entries as [$rule, $name]) {
+            if (str_starts_with($name, '/')) {
+                $parts[] = sprintf('{"rule":"%s","file":"%s"}', $rule, $name);
+
+                continue;
+            }
+
+            $parts[] = sprintf('{"rule":"%s","file":"%%s/%s"}', $rule, $name);
+            $args[] = '"$d"';
+        }
+
+        $format = '{"version":"1.19.0","matches":['.implode(',', $parts).']}\n';
+
+        return $this->stubBinary(
+            'for a in "$@"; do d="$a"; done; '
+            .'printf '.escapeshellarg($format).($args === [] ? '' : ' '.implode(' ', $args))
+        );
+    }
+
+    /**
+     * Shell fragment printing a canary-only match list, for stubs that need to
+     * do something else first. Assumes `$d` holds the staging directory.
+     */
+    private function printCanaryJson(): string
+    {
+        return 'printf '.escapeshellarg(
+            '{"version":"1.19.0","matches":[{"rule":"Canary_Rule","file":"%s/'.YaraXScanner::CANARY_NAME.'"}]}\n'
+        ).' "$d"';
+    }
+
     private function scanner(string $binary, ?string $rulesPath = null, bool $compiledRules = false, int $timeoutSeconds = 10): YaraXScanner
     {
         return new YaraXScanner($binary, $rulesPath ?? $this->rulesFile, $compiledRules, $timeoutSeconds);
     }
 
-    public function test_clean_scan_returns_empty_list()
+    public function test_empty_batch_returns_empty_and_never_runs_the_engine()
     {
-        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[]}\'');
+        $marker = $this->workDir.'/ran.txt';
+        $binary = $this->stubBinary('touch '.escapeshellarg($marker));
 
-        $this->assertSame([], $this->scanner($binary)->scan($this->targetFile));
+        $this->assertSame([], $this->scanner($binary)->scan([]));
+        $this->assertFileDoesNotExist($marker);
+    }
+
+    public function test_clean_batch_returns_no_matched_paths()
+    {
+        $this->assertSame([], $this->scanner($this->matchingStub())->scan([$this->targetFile]));
+    }
+
+    public function test_matches_map_back_to_the_caller_paths()
+    {
+        $second = $this->workDir.'/second.txt';
+        file_put_contents($second, 'also scan me');
+
+        $matches = $this->scanner($this->matchingStub([['Rule_B', 'f1']]))
+            ->scan([$this->targetFile, $second]);
+
+        // f1 is the second path staged, so only that one comes back matched.
+        $this->assertSame([$second => ['Rule_B']], $matches);
     }
 
     public function test_match_returns_deduplicated_rule_identifiers()
     {
-        $binary = $this->stubBinary(
-            'echo \'{"version":"1.19.0","matches":[{"rule":"Rule_A","file":"/tmp/x"},{"rule":"Rule_B","file":"/tmp/x"},{"rule":"Rule_A","file":"/tmp/x"}]}\''
+        $stub = $this->matchingStub([['Rule_A', 'f0'], ['Rule_B', 'f0'], ['Rule_A', 'f0']]);
+
+        $this->assertSame(
+            [$this->targetFile => ['Rule_A', 'Rule_B']],
+            $this->scanner($stub)->scan([$this->targetFile]),
+        );
+    }
+
+    public function test_unmatched_canary_is_scan_failure()
+    {
+        // No canary match means the engine scanned nothing, or the configured
+        // ruleset is not the one the image was built with. Either way an empty
+        // match list is not evidence the files are clean.
+        $stub = $this->matchingStub(withCanary: false);
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->expectExceptionMessage('canary');
+        $this->scanner($stub)->scan([$this->targetFile]);
+    }
+
+    public function test_match_on_a_file_that_was_never_staged_is_scan_failure()
+    {
+        $stub = $this->matchingStub([['Rule_A', 'f7']]);
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->expectExceptionMessage('not given');
+        $this->scanner($stub)->scan([$this->targetFile]);
+    }
+
+    public function test_canary_named_file_outside_the_staging_directory_does_not_satisfy_the_control()
+    {
+        // The canary's authority comes from being the file this invocation
+        // planted in this directory. A same-named file reported from anywhere
+        // else must not stand in for it, or the positive control is defeated by
+        // a filename.
+        $stub = $this->matchingStub(
+            [['Impostor_Rule', '/elsewhere/'.YaraXScanner::CANARY_NAME]],
+            withCanary: false,
         );
 
-        $this->assertSame(['Rule_A', 'Rule_B'], $this->scanner($binary)->scan($this->targetFile));
+        $this->expectException(MalwareScanFailedException::class);
+        $this->expectExceptionMessage('canary');
+        $this->scanner($stub)->scan([$this->targetFile]);
+    }
+
+    public function test_staging_directory_is_private()
+    {
+        $modeFile = $this->workDir.'/mode.txt';
+        $binary = $this->stubBinary(
+            'for a in "$@"; do d="$a"; done; '
+            .'stat -c %a "$d" > '.escapeshellarg($modeFile).'; '
+            .$this->printCanaryJson()
+        );
+
+        $this->scanner($binary)->scan([$this->targetFile]);
+
+        // Uploads and a live EICAR sample sit here; nothing else on the box
+        // needs to read them.
+        $this->assertSame('700', trim(file_get_contents($modeFile)));
+    }
+
+    public function test_batch_is_staged_as_real_files_never_symlinks()
+    {
+        // A symlink inside a directory target is skipped by the engine with no
+        // error and no match, which would read back as clean. Pin that staging
+        // never produces one, and that the canary is really there.
+        $manifest = $this->workDir.'/manifest.txt';
+        $binary = $this->stubBinary(
+            'for a in "$@"; do d="$a"; done; '
+            .'for f in "$d"/*; do '
+            .'if [ -L "$f" ]; then t=link; elif [ -f "$f" ]; then t=file; else t=other; fi; '
+            .'echo "$(basename "$f") $t $(wc -c < "$f")" >> '.escapeshellarg($manifest).'; '
+            .'done; '
+            .$this->printCanaryJson()
+        );
+
+        $second = $this->workDir.'/second.txt';
+        file_put_contents($second, 'a longer piece of content');
+
+        $this->scanner($binary)->scan([$this->targetFile, $second]);
+
+        $lines = file($manifest, FILE_IGNORE_NEW_LINES);
+        sort($lines);
+
+        $this->assertSame([
+            'f0 file '.filesize($this->targetFile),
+            'f1 file '.filesize($second),
+            YaraXScanner::CANARY_NAME.' file '.strlen(YaraXScanner::canaryContent()),
+        ], $lines);
+    }
+
+    public function test_symlinked_source_is_staged_as_a_real_file()
+    {
+        // The caller may hand us a symlink; staging must dereference it rather
+        // than carry the symlink into the batch, where it would be skipped.
+        $link = $this->workDir.'/link.txt';
+        symlink($this->targetFile, $link);
+
+        $manifest = $this->workDir.'/manifest.txt';
+        $binary = $this->stubBinary(
+            'for a in "$@"; do d="$a"; done; '
+            .'if [ -L "$d/f0" ]; then echo link > '.escapeshellarg($manifest).'; '
+            .'else echo "file $(wc -c < "$d/f0")" > '.escapeshellarg($manifest).'; fi; '
+            .$this->printCanaryJson()
+        );
+
+        $this->scanner($binary)->scan([$link]);
+
+        $this->assertSame('file '.filesize($this->targetFile), trim(file_get_contents($manifest)));
+    }
+
+    public function test_staging_directory_is_removed_after_a_scan()
+    {
+        $dirFile = $this->workDir.'/dir.txt';
+        $binary = $this->stubBinary(
+            'for a in "$@"; do d="$a"; done; echo "$d" > '.escapeshellarg($dirFile).'; '
+            .$this->printCanaryJson()
+        );
+
+        $this->scanner($binary)->scan([$this->targetFile]);
+
+        $this->assertDirectoryDoesNotExist(trim(file_get_contents($dirFile)));
+    }
+
+    public function test_staging_directory_is_removed_after_a_failed_scan()
+    {
+        $dirFile = $this->workDir.'/dir.txt';
+        $binary = $this->stubBinary(
+            'for a in "$@"; do d="$a"; done; echo "$d" > '.escapeshellarg($dirFile).'; '
+            .'echo \'boom\' >&2; exit 1'
+        );
+
+        try {
+            $this->scanner($binary)->scan([$this->targetFile]);
+            $this->fail('Expected MalwareScanFailedException');
+        } catch (MalwareScanFailedException $e) {
+            $this->assertDirectoryDoesNotExist(trim(file_get_contents($dirFile)));
+        }
     }
 
     public function test_stderr_with_exit_zero_is_scan_failure()
     {
-        // yr's most dangerous behavior: an unreadable TARGET file exits 0 with
-        // empty matches and the error on stderr only. Trusting stdout alone
-        // would silently fail open.
+        // yr's most dangerous behavior: an unreadable target exits 0 with empty
+        // matches and the error on stderr only. Trusting stdout alone would
+        // silently fail open.
         $binary = $this->stubBinary(
             'echo \'{"version":"1.19.0","matches":[]}\'; echo \'error: can not open target\' >&2'
         );
 
         $this->expectException(MalwareScanFailedException::class);
-        $this->scanner($binary)->scan($this->targetFile);
+        $this->scanner($binary)->scan([$this->targetFile]);
     }
 
     public function test_nonzero_exit_is_scan_failure()
@@ -95,7 +302,7 @@ class YaraXScannerTest extends TestCase
         $binary = $this->stubBinary('echo \'error: bad rules\' >&2; exit 1');
 
         $this->expectException(MalwareScanFailedException::class);
-        $this->scanner($binary)->scan($this->targetFile);
+        $this->scanner($binary)->scan([$this->targetFile]);
     }
 
     public function test_invalid_json_output_is_scan_failure()
@@ -103,7 +310,7 @@ class YaraXScannerTest extends TestCase
         $binary = $this->stubBinary('echo \'not json at all\'');
 
         $this->expectException(MalwareScanFailedException::class);
-        $this->scanner($binary)->scan($this->targetFile);
+        $this->scanner($binary)->scan([$this->targetFile]);
     }
 
     public function test_missing_matches_key_is_scan_failure()
@@ -111,7 +318,7 @@ class YaraXScannerTest extends TestCase
         $binary = $this->stubBinary('echo \'{"version":"1.19.0"}\'');
 
         $this->expectException(MalwareScanFailedException::class);
-        $this->scanner($binary)->scan($this->targetFile);
+        $this->scanner($binary)->scan([$this->targetFile]);
     }
 
     public function test_non_array_matches_is_scan_failure()
@@ -119,15 +326,25 @@ class YaraXScannerTest extends TestCase
         $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":"clean"}\'');
 
         $this->expectException(MalwareScanFailedException::class);
-        $this->scanner($binary)->scan($this->targetFile);
+        $this->scanner($binary)->scan([$this->targetFile]);
     }
 
     public function test_match_entry_without_rule_is_scan_failure()
     {
-        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[{"file":"/tmp/x"}]}\'');
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[{"file":"/staged/f0"}]}\'');
 
         $this->expectException(MalwareScanFailedException::class);
-        $this->scanner($binary)->scan($this->targetFile);
+        $this->scanner($binary)->scan([$this->targetFile]);
+    }
+
+    public function test_match_entry_without_file_is_scan_failure()
+    {
+        // Without a file there is no way to attribute the match, and guessing
+        // would either free a dirty file or condemn a clean one.
+        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[{"rule":"Rule_A"}]}\'');
+
+        $this->expectException(MalwareScanFailedException::class);
+        $this->scanner($binary)->scan([$this->targetFile]);
     }
 
     public function test_timeout_is_scan_failure()
@@ -136,75 +353,85 @@ class YaraXScannerTest extends TestCase
 
         $this->expectException(MalwareScanFailedException::class);
         $this->expectExceptionMessage('timed out');
-        $this->scanner($binary, timeoutSeconds: 1)->scan($this->targetFile);
+        $this->scanner($binary, timeoutSeconds: 1)->scan([$this->targetFile]);
     }
 
     public function test_missing_binary_is_scan_failure()
     {
         $this->expectException(MalwareScanFailedException::class);
-        $this->scanner($this->workDir.'/does_not_exist')->scan($this->targetFile);
+        $this->scanner($this->workDir.'/does_not_exist')->scan([$this->targetFile]);
     }
 
     public function test_missing_target_file_is_scan_failure()
     {
-        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[]}\'');
+        $binary = $this->matchingStub();
 
         $this->expectException(MalwareScanFailedException::class);
         $this->expectExceptionMessage('target is not readable');
-        $this->scanner($binary)->scan($this->workDir.'/missing.txt');
+        $this->scanner($binary)->scan([$this->workDir.'/missing.txt']);
     }
 
-    public function test_unreadable_target_file_is_scan_failure()
+    public function test_one_unreadable_file_fails_the_whole_batch()
     {
         if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
             $this->markTestSkipped('root can read anything; permission check not testable');
         }
 
-        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[]}\'');
-        chmod($this->targetFile, 0000);
+        $bad = $this->workDir.'/unreadable.txt';
+        file_put_contents($bad, 'secret');
+        chmod($bad, 0000);
 
         $this->expectException(MalwareScanFailedException::class);
         $this->expectExceptionMessage('target is not readable');
-        $this->scanner($binary)->scan($this->targetFile);
+        $this->scanner($this->matchingStub())->scan([$this->targetFile, $bad]);
     }
 
     public function test_missing_rules_path_is_scan_failure()
     {
-        $binary = $this->stubBinary('echo \'{"version":"1.19.0","matches":[]}\'');
+        $binary = $this->matchingStub();
 
         $this->expectException(MalwareScanFailedException::class);
         $this->expectExceptionMessage('rules path is not readable');
-        $this->scanner($binary, rulesPath: $this->workDir.'/missing-rules.yar')->scan($this->targetFile);
+        $this->scanner($binary, rulesPath: $this->workDir.'/missing-rules.yar')->scan([$this->targetFile]);
     }
 
     public function test_invokes_binary_with_expected_arguments()
     {
         $argsFile = $this->workDir.'/args.txt';
         $binary = $this->stubBinary(
-            'printf \'%s\n\' "$@" > '.escapeshellarg($argsFile).'; echo \'{"version":"1.19.0","matches":[]}\''
+            'for a in "$@"; do d="$a"; done; '
+            .'printf \'%s\n\' "$@" > '.escapeshellarg($argsFile).'; '
+            .$this->printCanaryJson()
         );
 
-        $this->scanner($binary)->scan($this->targetFile);
+        $this->scanner($binary)->scan([$this->targetFile]);
 
         $args = file($argsFile, FILE_IGNORE_NEW_LINES);
+        $target = array_pop($args);
+
         $this->assertSame([
             'scan',
             '--output-format=json',
             '--disable-warnings',
             '--',
             $this->rulesFile,
-            $this->targetFile,
         ], $args);
+
+        // One target, and it is the staging directory rather than any caller path.
+        $this->assertStringContainsString('/malware-scan-', $target);
+        $this->assertNotSame($this->targetFile, $target);
     }
 
     public function test_compiled_rules_flag_added_when_configured()
     {
         $argsFile = $this->workDir.'/args.txt';
         $binary = $this->stubBinary(
-            'printf \'%s\n\' "$@" > '.escapeshellarg($argsFile).'; echo \'{"version":"1.19.0","matches":[]}\''
+            'for a in "$@"; do d="$a"; done; '
+            .'printf \'%s\n\' "$@" > '.escapeshellarg($argsFile).'; '
+            .$this->printCanaryJson()
         );
 
-        $this->scanner($binary, compiledRules: true)->scan($this->targetFile);
+        $this->scanner($binary, compiledRules: true)->scan([$this->targetFile]);
 
         $args = file($argsFile, FILE_IGNORE_NEW_LINES);
         $this->assertContains('--compiled-rules', $args);
@@ -215,11 +442,19 @@ class YaraXScannerTest extends TestCase
         $binary = $this->stubBinary('head -c 5000 /dev/zero | tr \'\0\' \'e\' >&2; exit 1');
 
         try {
-            $this->scanner($binary)->scan($this->targetFile);
+            $this->scanner($binary)->scan([$this->targetFile]);
             $this->fail('Expected MalwareScanFailedException');
         } catch (MalwareScanFailedException $e) {
             $this->assertLessThanOrEqual(1000, strlen($e->getExtra()['stderr']));
         }
+    }
+
+    public function test_canary_content_is_the_eicar_test_string()
+    {
+        $this->assertSame(
+            '275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f',
+            hash('sha256', YaraXScanner::canaryContent()),
+        );
     }
 
     public function test_from_config_uses_defaults()


### PR DESCRIPTION
## Summary

- Makes the batch, not the file, the unit of a malware scan. Ruleset load dominates scan cost (roughly a millisecond per rule, paid per invocation and largely independent of file size), so scanning file by file multiplied the expensive part by the file count and put multi-file uploads past an API gateway timeout. Measured on one core with a 540-rule set, a 10-file 25MB upload goes from **15.3s to 5.4s**.
- `MalwareScanner::scan()` takes a list of paths and returns matched paths mapped to the rules they matched. `YaraXScanner` stages the batch into a private `0700` directory and scans that directory once, because the CLI accepts exactly one target.
- Staging hard-links or copies and **never symlinks**. A symlink inside a directory target is skipped silently by the engine, with no match and no stderr, which would read back as a clean verdict. Sources are resolved first (`link()` does not follow symlinks) and each staged entry is verified rather than assumed.
- Every batch carries a known-malicious canary, matched back by exact staged path. "No matches" and "scanned nothing" produce identical engine output, so an unmatched canary is a scan failure rather than a clean pass. This is what catches a `rules_path` pointing at a readable but wrong ruleset.
- A verdict naming a file that was never submitted now fails the scan instead of being ignored, so a backend reporting a renamed or resolved path cannot turn a detection into a stored upload. Results are attributed by path, so uploads sharing a client filename keep their own matched rules.

## Backwards compatibility

**Breaking.** `MalwareScanner::scan(string $path): list<string>` becomes `scan(array $paths): array<string, list<string>>`, with clean paths absent from the result. Custom scanner backends and any direct callers need updating; consumers that go through `AttachmentService` do not. `FakeMalwareScanner` keeps its factory helpers and gains a `$batches` property for asserting a single invocation.

Two couplings this introduces, both documented in `docs/malware-scanning.md`:

- The configured ruleset must detect the EICAR test string, or every scan fails closed. The baseline ruleset does.
- Host antivirus scanning the system temp directory will quarantine the canary and take uploads down with a 503. Exclude the `malware-scan-*` staging prefix.

## Engine behaviour this relies on (yara-x 1.19.0)

| Behaviour | Verified |
|---|---|
| `scan` accepts exactly one TARGET, which may be a directory | `yr scan --help` |
| A directory target reports each match with its absolute path, exit 0 either way | measured |
| A symlink in a directory target is skipped silently (no match, no stderr) | measured, pinned by an integration test |
| An unreadable *regular* file in a directory target does write to stderr | measured, so the existing any-stderr rule already covers it |

## Test plan

- [x] 666 tests pass, 0 failures (`vendor/bin/phpunit`)
- [x] 10 integration tests green against a real `yr` 1.19.0 binary, including batch attribution, symlinked sources, the engine's symlink skip, and a ruleset that cannot catch the canary
- [x] New unit coverage for staging (real files never symlinks, private directory mode, cleanup on success and failure), canary impersonation from outside the staging directory, matches on unstaged files, and per-file failure attribution
- [x] Laravel Pint clean on every changed file
- [x] Reviewed by two external models; six findings applied, one recorded as pre-existing and out of scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uploads are now malware-scanned as a complete batch, improving consistency across multi-file uploads.
  * Detected threats are accurately linked to their uploaded files and reported in upload order.
* **Bug Fixes**
  * Improved handling of unreadable files, incomplete scan results, unexpected scanner output, and suspicious staging behavior.
  * Scans now fail safely when results cannot be trusted, helping prevent missed detections.
* **Documentation**
  * Updated malware-scanning guidance to describe batch processing, timeouts, resource limits, and staging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->