### PR TITLE
fix(remote): resolve contextual headers per call, not per repository

### DIFF
--- a/docs/RemoteRepository.md
+++ b/docs/RemoteRepository.md
@@ -276,6 +276,10 @@ The resolver is only called when:
 
 If the resolver returns `null`, the header is not added to outgoing requests.
 
+**Resolvers run on every outbound call, not once per repository.** Keep them cheap and free of side effects: read state and return, never make a remote call or a query. The resolved value is not cached, because a repository is typically registered as a container singleton and therefore outlives the request or queue job that first used it. Caching would let the first caller's context be sent on every later caller's requests from the same process, which is a wrong value rather than a missing one.
+
+A corollary worth designing for: a resolver may legitimately return a different value, or `null`, on a later call from the same instance. That is the point.
+
 ### Request Priority
 
 For contextual headers, **incoming request headers take priority** over resolver values. This allows upstream services to override values when needed:

--- a/docs/distributed-tracing.md
+++ b/docs/distributed-tracing.md
@@ -265,18 +265,29 @@ Enable request logging to debug trace propagation:
 
 ### Verification
 
-Check that headers are being propagated correctly:
+Outbound headers are assembled per call and are not readable from a subclass, so
+verify them from what the client is handed rather than from repository state.
+
+Enable request logging and read the emitted entry:
 
 ```php
-// In RemoteRepository implementation
-protected function filter(array $data)
-{
-    Log::debug('Remote request headers', [
-        'headers' => $this->headers  // Check X-Amzn-Trace-Id is present
-    ]);
-    
-    // Continue with API call...
-}
+// config/app.php
+'remote_repository' => [
+    'log_requests' => true,
+],
+```
+
+`POST` logs the outbound header *names* under `Request Debug`, and `GET` logs the
+URL under `API GET`. Values are deliberately omitted: the set carries the machine
+token and the caller's actor context. To see values, capture them at the client,
+which is also how to assert on them in a test:
+
+```php
+$client->method('get')->willReturnCallback(function ($url, $headers) {
+    $this->assertArrayHasKey('X-Amzn-Trace-Id', $headers);
+
+    return new Document;
+});
 ```
 
 ## Migration Guide

--- a/src/RemoteRepositories/RemoteRepository.php
+++ b/src/RemoteRepositories/RemoteRepository.php
@@ -37,7 +37,10 @@ abstract class RemoteRepository
     private ?string $token = null;
 
     /**
-     * @var array - Headers to be sent with each request
+     * @var array - Headers that belong to this repository rather than to a
+     *            single call: the content negotiation pair and, once loaded,
+     *            the machine token. Per-call headers are built by
+     *            requestHeaders() and never stored here.
      */
     private array $headers;
 
@@ -87,23 +90,51 @@ abstract class RemoteRepository
 
         // Update Authorization header with the loaded token
         $this->headers['Authorization'] = 'Bearer '.$this->token;
+    }
+
+    /**
+     * Build the headers for a single outbound call.
+     *
+     * Everything that describes *this* call is resolved here rather than
+     * cached on the instance: the trace identifiers, the passthrough headers,
+     * and the contextual headers with their resolvers. Repositories are
+     * container singletons, so a value cached at first use outlives the
+     * request or queue job that produced it. In a worker that means the first
+     * job to touch a repository would stamp its trace and its acting actor
+     * onto every later job in the same process, which is a wrong attribution
+     * rather than a missing one.
+     *
+     * The token is the exception and stays cached by ensureTokenLoaded(): it
+     * identifies the calling service, which does not vary per call.
+     *
+     * Private deliberately. Nothing should override how a call's headers are
+     * assembled - a consumer that needs to contribute one registers a
+     * contextual-header resolver instead - and a private method on this base
+     * class cannot collide with a same-named method in the many subclasses
+     * across consuming services.
+     */
+    private function requestHeaders(): array
+    {
+        $this->ensureTokenLoaded();
+
+        $headers = $this->headers;
 
         // Add request ID if available
         $requestId = $this->getCurrentRequestId();
         if ($requestId) {
-            $this->headers['X-Request-ID'] = $requestId;
+            $headers['X-Request-ID'] = $requestId;
         }
 
         // Add X-Ray trace header if available (preserves full trace context)
         $traceHeader = $this->getCurrentTraceHeader();
         if ($traceHeader) {
-            $this->headers['X-Amzn-Trace-Id'] = $traceHeader;
+            $headers['X-Amzn-Trace-Id'] = $traceHeader;
         }
 
         // Add correlation ID as fallback for non-X-Ray scenarios
         $traceId = $this->getCurrentTraceId();
         if ($traceId) {
-            $this->headers['X-Correlation-ID'] = $traceId;
+            $headers['X-Correlation-ID'] = $traceId;
         }
 
         // Passthrough headers - forward if present in incoming request
@@ -111,7 +142,7 @@ abstract class RemoteRepository
         foreach ($passthroughHeaders as $header) {
             $value = request()?->headers->get($header);
             if ($value !== null) {
-                $this->headers[$header] = $value;
+                $headers[$header] = $value;
             }
         }
 
@@ -130,9 +161,11 @@ abstract class RemoteRepository
             }
 
             if ($value !== null) {
-                $this->headers[$header] = $value;
+                $headers[$header] = $value;
             }
         }
+
+        return $headers;
     }
 
     /**
@@ -304,8 +337,8 @@ abstract class RemoteRepository
             throw new \RuntimeException('Client not initialized - tests should mock this repository');
         }
 
-        // Lazy-load token on first request
-        $this->ensureTokenLoaded();
+        // Lazy-load token on first request, then build this call's headers
+        $headers = $this->requestHeaders();
 
         $startTime = $this->profileStart(__METHOD__);
         $retry = $this->retry;
@@ -330,7 +363,7 @@ abstract class RemoteRepository
                     Log::debug('API GET', ['url' => $url]);
                 }
 
-                $res = $this->client->get($url, $this->headers);
+                $res = $this->client->get($url, $headers);
 
                 if ($res->hasErrors()) {
                     // Check for specialized error patterns before general handling
@@ -406,8 +439,8 @@ abstract class RemoteRepository
             throw new \RuntimeException('Client not initialized - tests should mock this repository');
         }
 
-        // Lazy-load token on first request
-        $this->ensureTokenLoaded();
+        // Lazy-load token on first request, then build this call's headers
+        $headers = $this->requestHeaders();
 
         $startTime = $this->profileStart(__METHOD__);
         $retry = $this->retry;
@@ -416,7 +449,7 @@ abstract class RemoteRepository
             try {
                 Log::debug('getUserUrl', ['url' => $url]);
 
-                $res = $this->client->get($url, $this->headers);
+                $res = $this->client->get($url, $headers);
 
                 if ($res->hasErrors()) {
                     $errorMessages = [];
@@ -456,8 +489,8 @@ abstract class RemoteRepository
             throw new \RuntimeException('Client not initialized - tests should mock this repository');
         }
 
-        // Lazy-load token on first request
-        $this->ensureTokenLoaded();
+        // Lazy-load token on first request, then build this call's headers
+        $headers = $this->requestHeaders();
 
         $startTime = $this->profileStart(__METHOD__);
         $retry = $this->retry;
@@ -468,12 +501,14 @@ abstract class RemoteRepository
                     Log::info('Request Debug', [
                         'url' => $url,
                         'body' => $data->toArray(),
-                        'headers' => $this->headers,
+                        // Names only: the set carries the machine token and the
+                        // caller's actor context, neither of which belongs in a log.
+                        'header_names' => array_keys($headers),
                     ]);
                     Log::debug('API POST', ['url' => $url]);
                 }
 
-                $res = $this->client->post($url, $data, $this->headers);
+                $res = $this->client->post($url, $data, $headers);
 
                 if ($res->hasErrors()) {
                     $httpResponse = $res->getResponse();

--- a/tests/Unit/RemoteRepositories/RemoteRepositoryHeaderForwardingTest.php
+++ b/tests/Unit/RemoteRepositories/RemoteRepositoryHeaderForwardingTest.php
@@ -26,11 +26,7 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
 
     protected function getHeadersFromRepository(RemoteRepository $repository): array
     {
-        $reflection = new \ReflectionClass(RemoteRepository::class);
-        $headersProperty = $reflection->getProperty('headers');
-        $headersProperty->setAccessible(true);
-
-        return $headersProperty->getValue($repository);
+        return $repository->triggerRequestHeaders();
     }
 
     // ==================== Passthrough Headers ====================
@@ -44,7 +40,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -60,7 +55,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -77,7 +71,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -96,7 +89,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -113,7 +105,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -133,7 +124,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -157,7 +147,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -181,7 +170,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -200,7 +188,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -222,7 +209,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -244,7 +230,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -269,7 +254,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -290,7 +274,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -311,7 +294,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -338,7 +320,6 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->app->instance('request', $request);
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
-        $repository->triggerTokenLoad();
 
         $headers = $this->getHeadersFromRepository($repository);
 
@@ -346,6 +327,66 @@ class RemoteRepositoryHeaderForwardingTest extends TestCase
         $this->assertEquals('passthrough-value', $headers['X-Custom-Header']);
         $this->assertArrayHasKey('X-Context-Header', $headers);
         $this->assertEquals('resolved-value', $headers['X-Context-Header']);
+    }
+
+    // ==================== Per-call resolution ====================
+
+    public function test_contextual_header_is_resolved_on_every_call()
+    {
+        $resolver = new MutableTestHeaderResolver('actor-one');
+        $this->app->instance(MutableTestHeaderResolver::class, $resolver);
+
+        config(['app.remote_repository.contextual_headers' => [
+            'X-Context-Header' => MutableTestHeaderResolver::class,
+        ]]);
+
+        $this->app->instance('request', Request::create('/api/test', 'GET'));
+
+        $repository = $this->createTestRepositoryWithTokenTrigger();
+
+        $first = $this->getHeadersFromRepository($repository);
+        $resolver->value = 'actor-two';
+        $second = $this->getHeadersFromRepository($repository);
+
+        // Repositories are container singletons, so a value cached at first
+        // use would follow this instance for the life of the process.
+        $this->assertEquals('actor-one', $first['X-Context-Header']);
+        $this->assertEquals('actor-two', $second['X-Context-Header']);
+    }
+
+    public function test_contextual_header_is_dropped_when_a_later_call_has_no_actor()
+    {
+        $resolver = new MutableTestHeaderResolver('actor-one');
+        $this->app->instance(MutableTestHeaderResolver::class, $resolver);
+
+        config(['app.remote_repository.contextual_headers' => [
+            'X-Context-Header' => MutableTestHeaderResolver::class,
+        ]]);
+
+        $this->app->instance('request', Request::create('/api/test', 'GET'));
+
+        $repository = $this->createTestRepositoryWithTokenTrigger();
+
+        $first = $this->getHeadersFromRepository($repository);
+        $resolver->value = null;
+        $second = $this->getHeadersFromRepository($repository);
+
+        // A queue worker runs one job with an actor and the next without one.
+        // The second must send no actor rather than inherit the first's.
+        $this->assertArrayHasKey('X-Context-Header', $first);
+        $this->assertArrayNotHasKey('X-Context-Header', $second);
+    }
+}
+
+// Test resolver whose answer changes between calls, standing in for a resolver
+// reading request or job state that differs per call
+class MutableTestHeaderResolver implements HeaderResolverInterface
+{
+    public function __construct(public ?string $value) {}
+
+    public function resolve(): ?string
+    {
+        return $this->value;
     }
 }
 

--- a/tests/Unit/RemoteRepositories/RemoteRepositoryTracingTest.php
+++ b/tests/Unit/RemoteRepositories/RemoteRepositoryTracingTest.php
@@ -3,7 +3,6 @@
 namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\RemoteRepositories;
 
 use Illuminate\Http\Request;
-use NuiMarkets\LaravelSharedUtils\RemoteRepositories\RemoteRepository;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 use NuiMarkets\LaravelSharedUtils\Tests\Utils\RemoteRepositoryTestHelpers;
 
@@ -21,11 +20,7 @@ class RemoteRepositoryTracingTest extends TestCase
     {
         $repository = $this->createTestRepositoryWithTokenTrigger();
 
-        // Use reflection to access protected headers property
-        $reflection = new \ReflectionClass(RemoteRepository::class);
-        $headersProperty = $reflection->getProperty('headers');
-        $headersProperty->setAccessible(true);
-        $headers = $headersProperty->getValue($repository);
+        $headers = $repository->triggerRequestHeaders();
 
         $this->assertArrayNotHasKey('X-Request-ID', $headers);
         $this->assertArrayNotHasKey('X-Correlation-ID', $headers);
@@ -39,14 +34,7 @@ class RemoteRepositoryTracingTest extends TestCase
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
 
-        // Trigger token loading to populate headers
-        $repository->triggerTokenLoad();
-
-        // Use reflection to access protected headers property
-        $reflection = new \ReflectionClass(RemoteRepository::class);
-        $headersProperty = $reflection->getProperty('headers');
-        $headersProperty->setAccessible(true);
-        $headers = $headersProperty->getValue($repository);
+        $headers = $repository->triggerRequestHeaders();
 
         $this->assertArrayHasKey('X-Request-ID', $headers);
         $this->assertEquals('fallback-request-456', $headers['X-Request-ID']);
@@ -61,14 +49,7 @@ class RemoteRepositoryTracingTest extends TestCase
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
 
-        // Trigger token loading to populate headers
-        $repository->triggerTokenLoad();
-
-        // Use reflection to access protected headers property
-        $reflection = new \ReflectionClass(RemoteRepository::class);
-        $headersProperty = $reflection->getProperty('headers');
-        $headersProperty->setAccessible(true);
-        $headers = $headersProperty->getValue($repository);
+        $headers = $repository->triggerRequestHeaders();
 
         // Should propagate full X-Ray header for AWS trace continuity
         $this->assertArrayHasKey('X-Amzn-Trace-Id', $headers);
@@ -88,14 +69,7 @@ class RemoteRepositoryTracingTest extends TestCase
 
         $repository = $this->createTestRepositoryWithTokenTrigger();
 
-        // Trigger token loading to populate headers
-        $repository->triggerTokenLoad();
-
-        // Use reflection to access protected headers property
-        $reflection = new \ReflectionClass(RemoteRepository::class);
-        $headersProperty = $reflection->getProperty('headers');
-        $headersProperty->setAccessible(true);
-        $headers = $headersProperty->getValue($repository);
+        $headers = $repository->triggerRequestHeaders();
 
         // Should propagate malformed header as-is for X-Ray
         $this->assertArrayHasKey('X-Amzn-Trace-Id', $headers);

--- a/tests/Utils/RemoteRepositoryTestHelpers.php
+++ b/tests/Utils/RemoteRepositoryTestHelpers.php
@@ -5,6 +5,7 @@ namespace NuiMarkets\LaravelSharedUtils\Tests\Utils;
 use Mockery;
 use NuiMarkets\LaravelSharedUtils\Contracts\MachineTokenServiceInterface;
 use NuiMarkets\LaravelSharedUtils\RemoteRepositories\RemoteRepository;
+use Swis\JsonApi\Client\Document;
 use Swis\JsonApi\Client\ErrorCollection;
 use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;
 use Swis\JsonApi\Client\Interfaces\DocumentInterface;
@@ -72,6 +73,30 @@ trait RemoteRepositoryTestHelpers
     }
 
     /**
+     * Create a mock client that records the headers of each outbound GET.
+     *
+     * Header assembly is private to RemoteRepository, so tests observe it the
+     * way a downstream service does: by looking at what actually goes out.
+     */
+    protected function createCapturingClient(\ArrayObject $captured): DocumentClientInterface
+    {
+        $client = $this->createMock(DocumentClientInterface::class);
+        $client->expects($this->any())
+            ->method('setBaseUri')
+            ->with($this->isType('string'));
+        $client->method('getBaseUri')->willReturn('https://test.example.com');
+        $client->method('get')->willReturnCallback(
+            function ($url, $headers) use ($captured) {
+                $captured->exchangeArray($headers);
+
+                return new Document;
+            }
+        );
+
+        return $client;
+    }
+
+    /**
      * Create a mock DocumentClientInterface with setBaseUri expectation.
      */
     protected function createMockClient(): DocumentClientInterface
@@ -106,11 +131,20 @@ trait RemoteRepositoryTestHelpers
      */
     protected function createTestRepositoryWithTokenTrigger(?DocumentClientInterface $client = null, ?MachineTokenServiceInterface $tokenService = null): RemoteRepository
     {
-        $client = $client ?? $this->createMockClient();
+        $captured = new \ArrayObject;
+        $client = $client ?? $this->createCapturingClient($captured);
         $tokenService = $tokenService ?? $this->createMockTokenService();
 
-        return new class($client, $tokenService) extends RemoteRepository
+        return new class($client, $tokenService, $captured) extends RemoteRepository
         {
+            public function __construct(
+                DocumentClientInterface $client,
+                MachineTokenServiceInterface $tokenService,
+                private \ArrayObject $captured
+            ) {
+                parent::__construct($client, $tokenService);
+            }
+
             protected function filter(array $data)
             {
                 return $data;
@@ -119,6 +153,20 @@ trait RemoteRepositoryTestHelpers
             public function triggerTokenLoad(): void
             {
                 $this->ensureTokenLoaded();
+            }
+
+            /**
+             * The headers this repository sends on a call made right now.
+             *
+             * Per-call headers are not stored on the instance and their
+             * assembly is private, so this makes a real call and reports what
+             * the client received.
+             */
+            public function triggerRequestHeaders(): array
+            {
+                $this->get('probe');
+
+                return $this->captured->getArrayCopy();
             }
         };
     }


### PR DESCRIPTION
## Summary

- Contextual, passthrough and trace headers were built alongside the token in `ensureTokenLoaded()`, behind the same "already loaded" guard, and cached on the instance. Repositories are typically container singletons, so that cache outlives the request or job that filled it. In a queue worker the first job to touch a repository stamped its trace and its resolved context onto every later job in the same process, which is a wrong attribution rather than a missing one.
- Split the two lifetimes. `ensureTokenLoaded()` keeps only the token, which identifies the calling service and does not vary per call. A new private `requestHeaders()` builds everything that describes a single call, and `get()`, `getUserUrl()` and `post()` send its result.
- **Within one request this is byte-identical to the old behaviour.** All three trace getters are pure reads off `request()->headers`, and nothing mutates those mid-request, so the first and fiftieth call of a request resolve the same values. The difference appears only when the instance outlives the request, which is the case being fixed.
- Also corrects `X-Request-ID` / `X-Amzn-Trace-Id` / `X-Correlation-ID`, frozen the same way, which mis-correlated a worker's traces to whichever job happened to boot the repository first.

## Consumer-visible contract change

Resolvers now run **once per outbound call** instead of once per repository instance, and their result is not cached. Keep them cheap and side-effect free, and expect a later call from the same instance to legitimately resolve a different value or none. Documented in `docs/RemoteRepository.md`.

`requestHeaders()` is private, so it cannot collide with a same-named method in a subclass, and `$headers` was already private. `ensureTokenLoaded()` is unchanged. A subclass that overrode it to push extra headers onto `$this->headers` still works, and keeps its own per-instance caching.

## Docs

`docs/distributed-tracing.md` told consumers to verify propagation by logging `$this->headers` from a subclass `filter()`. That could never work (the property is private) and after this change it would show only the three base headers. Replaced with the two approaches that do work: enabling request logging, and asserting on the headers the client is handed.

## Review

Two independent external reviewers, both clean on correctness: token-load failure ordering is preserved relative to profiling and the retry loop, headers are stable across retries within one call, and no remaining read of the cached property sees an incomplete set. Both findings raised were applied - making `requestHeaders()` private rather than protected, and the broken tracing-doc example.

## Test plan

- [x] Full suite: 668 tests. The single failure (`ClearLadaAndResponseCacheControllerTest::it_clears_lada_keys_across_multiple_scan_batches`) is pre-existing on the base commit, seed-dependent, and untouched by this diff
- [x] Both new regression tests confirmed to fail against a deliberately re-cached implementation
- [x] Assertion and issue counts on the touched tests match the base commit exactly (278 assertions, 70 deprecations, 5 notices)
- [x] Exercised from a downstream consumer with this file in `vendor/`: 17/17 pass, versus 1 failure without it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured request-specific headers, including request IDs, tracing, passthrough, and contextual headers, are refreshed for every outbound request.
  - Prevented stale contextual headers from persisting when resolver results change or become unavailable.
  - Improved outbound request logging to reflect the headers actually sent.

- **Documentation**
  - Clarified contextual header resolver behavior and caching expectations.
  - Updated distributed tracing guidance to verify headers from captured client requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->