### PR TITLE
Remove the unreachable request-context branch from UUID filter logging

### DIFF
--- a/src/RemoteRepositories/UuidValidatingRemoteRepository.php
+++ b/src/RemoteRepositories/UuidValidatingRemoteRepository.php
@@ -3,7 +3,6 @@
 namespace NuiMarkets\LaravelSharedUtils\RemoteRepositories;
 
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Request;
 
 /**
  * Remote repository that validates UUIDs before making API calls.
@@ -57,16 +56,6 @@ abstract class UuidValidatingRemoteRepository extends RemoteRepository
                 'valid_count' => count($validUuids),
                 'invalid_uuids' => $invalidUuids,
             ];
-
-            // Add request context if available (defensive logging)
-            if (! Request::has('is_machine')) {
-                if (Request::user()) {
-                    $logData['request.user_id'] = Request::user()->id ?? null;
-                    $logData['request.org_id'] = Request::user()->org_id ?? null;
-                }
-                $logData['request.method'] = Request::method();
-                $logData['request.path'] = Request::path();
-            }
 
             Log::warning('Invalid UUIDs filtered from RemoteRepository query', $logData);
         }

--- a/tests/Unit/RemoteRepositories/UuidValidatingRemoteRepositoryTest.php
+++ b/tests/Unit/RemoteRepositories/UuidValidatingRemoteRepositoryTest.php
@@ -150,6 +150,30 @@ class UuidValidatingRemoteRepositoryTest extends TestCase
         $this->assertCount(0, $result);
     }
 
+    public function test_log_payload_carries_only_diagnostic_keys()
+    {
+        // The warning payload is deliberately limited to what identifies the bad call.
+        // Request context (method, path, user_id, org_id) is injected into every log
+        // line by the ambient logging context, so repeating it here only adds noise.
+        // This assertion uses exact keys so that re-adding any of it fails loudly.
+        $captured = null;
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('Invalid UUIDs filtered from RemoteRepository query', Mockery::on(function ($logData) use (&$captured) {
+                $captured = $logData;
+
+                return true;
+            }));
+
+        $this->repository->test_filter_valid_uuids(['not-a-uuid']);
+
+        $this->assertSame(
+            ['repository', 'invalid_count', 'total_count', 'valid_count', 'invalid_uuids'],
+            array_keys($captured)
+        );
+    }
+
     public function test_find_by_ids_calls_filter_valid_uuids()
     {
         $mixedIds = [


### PR DESCRIPTION
## Summary

- `UuidValidatingRemoteRepository::filterValidUuids()` guarded its request-context block on `! Request::has('is_machine')`. Consuming services merge that key in their JWT middleware for **both** token paths (`true` for a machine caller, `false` for a person), so the condition is false on every route behind that middleware and the block has never executed.
- Verified against production rather than reasoned: across 5,187 occurrences of this log line in 90 days (dev, training and prod), none carries `request.method`, `request.path`, `request.user_id` or `request.org_id` inside its `data` payload.
- Reviving the branch would be the wrong repair, because what it adds is already there. `EnvironmentProcessor` (`src/Logging/EnvironmentProcessor.php:47,49`, pushed in `CustomizeMonoLog.php:38`) stamps `request.method` and `request.path` onto every record's `extra`; `RequestLoggingMiddleware::addUserContext()` (`:181-182`) puts `request.user_id` and `request.org_id` into `Log::withContext()` at `:88`. The block was redundant, not broken.
- Deleting it is also strictly more correct than keeping it. `EnvironmentProcessor` is console-aware (it contributes `command` instead of request fields when `runningInConsole()`), whereas the deleted block used the `Request` facade, which resolves a Request even in console context and would have stamped a fictitious `GET` / `/` onto queue and artisan logs.
- Also drops the now-unused `Illuminate\Support\Facades\Request` import; it was the class's only `Request` reference, and the parent uses the `request()` helper.
- Timing: the only consumer that extends this class still merges the flag. When it stops, the condition flips true and the block would begin executing for the first time across five repositories, a silent change in logging output arriving as a side effect of an unrelated migration. Better to settle it while nothing depends on it.

## Review

External reviewers (Codex GPT-5.5, GLM-5.2 agentic) on `8ec95f2`. GLM-5.2: APPROVE, no findings. Codex: one MEDIUM, `NEEDS_DISCUSSION`, resolved as documentation with no code change, so the pushed tree is the reviewed tree.

Codex's finding, and why it does not require a fallback: `RequestLoggingMiddleware` is opt-in (`config/logging-utils.php:43-44`, `'enabled' => false`), so a consumer could register the Monolog processor without the middleware and have no ambient `request.user_id` / `request.org_id`. Correct about the config, but the inferred regression is unreachable, because the two conditions are coupled through the same middleware. The guard opens only when `is_machine` is absent, which means the JWT middleware did not run, and that middleware is also what calls `setUserResolver()`. In the consuming service, `is_machine` is merged in the same block that sets the resolver on every path: machine tokens get `is_machine => true` alongside `setUserResolver(fn () => null)`, persons get `false` alongside a real user. So wherever the guard could have opened, `Request::user()` was already null and the block's inner `if (Request::user())` already failed, leaving only `method`/`path`, which `EnvironmentProcessor` supplies with no middleware dependency. Nothing loses attribution it was receiving.

## Changes

```
src/RemoteRepositories/UuidValidatingRemoteRepository.php        | 11 ----------
tests/Unit/RemoteRepositories/UuidValidatingRemoteRepositoryTest.php | 24 ++++++++++++++++++++++
2 files changed, 24 insertions(+), 11 deletions(-)
```

The five existing `Log::shouldReceive('warning')` assertions match individual keys via `Mockery::on()`, so they would not have failed on this change, or on the next one. The added `test_log_payload_carries_only_diagnostic_keys` uses `assertSame` on `array_keys` to pin the payload to its five diagnostic keys, so re-adding request context fails loudly and deliberately.

## Test plan

- [x] `vendor/bin/phpunit --filter UuidValidatingRemoteRepositoryTest` - 7 tests, 29 assertions, green
- [x] Full suite `composer test-all` - 669 tests, 2141 assertions, 668 pass
- [x] Confirmed the new test fails if the deleted branch is restored (independently verified by the agentic reviewer: under Testbench `Request::has('is_machine')` is false, so restoring it adds `request.method` / `request.path` and breaks the `assertSame`)
- [x] `pint --test` output for both touched files is byte-identical before and after
- [ ] **Known pre-existing failure, unrelated to this change**: `ClearLadaAndResponseCacheControllerTest::it_clears_lada_keys_across_multiple_scan_batches` fails at 1102 vs 1100. Reproduced identically on clean `master` with these two files stashed, and deterministic across repeated runs with a flushed Redis DB 1, so neither flaky nor caused by this branch. Root cause is separate and worth its own PR: Redis `SCAN` may return the same element more than once across cursor iterations, and `ClearLadaAndResponseCacheController::clearLadaKeys()` (`:155`) increments its counter per yielded key with no dedup, so any sweep spanning more than one iteration (over `SCAN_COUNT` = 1000 keys) can over-report. The deletion itself is unaffected, `UNLINK` on an already-unlinked key is a no-op; only the reported figure is wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invalid UUID warning logs by limiting them to relevant diagnostic information.
  * Preserved existing invalid UUID filtering and warning behavior.

* **Tests**
  * Added coverage to verify the warning log contains the expected diagnostic details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->