### PR TITLE
Keep sensitive exception diagnostics out of debug responses

### DIFF
--- a/docs/architecture/shared-types.md
+++ b/docs/architecture/shared-types.md
@@ -126,6 +126,12 @@ Thrown when a cached lookup failure is hit. Provides structured error context.
 
 Base class for HTTP request exceptions with standardized error handling.
 
+- `extra` is included in logs and Sentry, and may appear in client responses when
+  application debug responses are enabled. Store only client-safe context there.
+- `logExtra` is merged into logs and Sentry through `getLogContext()`, but is never
+  included in client responses. Use it for internal diagnostics such as local paths,
+  upstream response fragments, and engine output.
+
 ## Abstract Base Classes
 
 ### RemoteRepository

--- a/docs/malware-scanning.md
+++ b/docs/malware-scanning.md
@@ -62,7 +62,7 @@ ATTACHMENTS_MALWARE_SCAN_ENABLED=true
 
 | Exception | HTTP | Meaning |
 |-----------|------|---------|
-| `MalwareDetectedException` | 422 | A rule matched. Client-facing message names the file only; matched rule ids travel in the exception's `extra` (logs/Sentry) so detection logic isn't disclosed to clients. |
+| `MalwareDetectedException` | 422 | A rule matched. Client-facing message names the file only; matched rule ids travel in the exception's log-only context so detection logic isn't disclosed to clients, even when debug responses are enabled. |
 | `MalwareScanFailedException` | 503 | No trustworthy verdict (engine missing/broken/timeout). Retryable once the scanner is healthy. |
 
 Both extend `BaseHttpRequestException`, so services using `BaseErrorHandler` surface them consistently with no extra wiring. Services that catch-and-remap exceptions from `processAttachments()` should pass these two through untouched.

--- a/src/Exceptions/BaseErrorHandler.php
+++ b/src/Exceptions/BaseErrorHandler.php
@@ -188,7 +188,7 @@ class BaseErrorHandler extends ExceptionHandler
     /**
      * Return a minimal trace object for JSON output.
      */
-    protected function getExceptionTrace(\Throwable $e): array
+    protected function getExceptionTrace(Throwable $e): array
     {
         return [
             'file' => $e->getFile(),
@@ -215,10 +215,11 @@ class BaseErrorHandler extends ExceptionHandler
             'exception' => $e,
         ];
 
-        // Include structured context from BaseHttpRequestException (e.g. RemoteServiceException)
-        // so uncaught exceptions still produce rich log entries with api.service, api.status, etc.
-        if ($e instanceof BaseHttpRequestException && ! empty($e->getExtra())) {
-            $logContext = array_merge($e->getExtra(), $logContext);
+        // Include client-safe and log-only structured context from
+        // BaseHttpRequestException so uncaught exceptions still produce rich
+        // log entries without exposing diagnostics in debug responses.
+        if ($e instanceof BaseHttpRequestException && ! empty($e->getLogContext())) {
+            $logContext = array_merge($e->getLogContext(), $logContext);
         }
 
         Log::error(class_basename($e), $logContext);
@@ -234,12 +235,18 @@ class BaseErrorHandler extends ExceptionHandler
         $errorData = $this->getFormattedError($e);
 
         if (! $this->shouldReport($e)) {
+            $logContext = [
+                'errors' => $errorData['errors'],
+                'exception' => $e,
+            ];
+
+            if ($e instanceof BaseHttpRequestException && ! empty($e->getLogContext())) {
+                $logContext = array_merge($e->getLogContext(), $logContext);
+            }
+
             Log::info(
                 class_basename($e),
-                [
-                    'errors' => $errorData['errors'],
-                    'exception' => $e,
-                ],
+                $logContext,
             );
         }
 

--- a/src/Exceptions/BaseHttpRequestException.php
+++ b/src/Exceptions/BaseHttpRequestException.php
@@ -10,12 +10,14 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  * Note this is a replacement for the built in BadRequestHttpException which is hardcoded for 400 status
  * Also shown in response if APP_DEBUG=true and or log/sentry
  *  - custom "tag" data used by sentry
- *  - custom "extra" data used by sentry/logging
+ *  - custom "extra" data used by debug responses, sentry and logging
+ *  - custom "logExtra" data used only by sentry and logging
  *  - preserving previous exception if its re throwing
  *
  * Usage:
  *      new BaseHttpRequestException('Failed to create order', 500, $exception,
- *              tags: ['test' => 'tag'], extra: ['misc' => 123]);
+ *              tags: ['test' => 'tag'], extra: ['request_id' => 123],
+ *              logExtra: ['upstream_response' => $body]);
  *
  *  Note it's recommended to NOT use $e->getMessage() for message to avoid exposing the internal exception info in response
  */
@@ -27,13 +29,23 @@ class BaseHttpRequestException extends HttpException
 
     protected array $extra = [];
 
-    public function __construct(string $message, int $statusCode = 400, ?\Throwable $previous = null, array $tags = [], array $extra = [])
-    {
+    protected array $logExtra = [];
+
+    public function __construct(
+        string $message,
+        int $statusCode = 400,
+        ?\Throwable $previous = null,
+        array $tags = [],
+        array $extra = [],
+        array $logExtra = [],
+    ) {
         $this->previous = $previous;
         // Tags for Sentry
         $this->tags = $tags;
-        // Extra for logging/Sentry
+        // Extra for debug responses, logging and Sentry
         $this->extra = $extra;
+        // Sensitive diagnostic context for logging and Sentry only
+        $this->logExtra = $logExtra;
 
         if ($previous instanceof HttpException && $statusCode === 400) {
             $statusCode = $previous->getStatusCode();
@@ -52,6 +64,26 @@ class BaseHttpRequestException extends HttpException
         $this->extra = $extra;
 
         return $this;
+    }
+
+    public function getLogExtra(): array
+    {
+        return $this->logExtra;
+    }
+
+    public function withLogExtra(array $logExtra): self
+    {
+        $this->logExtra = $logExtra;
+
+        return $this;
+    }
+
+    /**
+     * Context for logs and Sentry. Log-only values win on a duplicate key.
+     */
+    public function getLogContext(): array
+    {
+        return array_merge($this->extra, $this->logExtra);
     }
 
     public function getTags(): array

--- a/src/Exceptions/MalwareDetectedException.php
+++ b/src/Exceptions/MalwareDetectedException.php
@@ -6,8 +6,8 @@ namespace NuiMarkets\LaravelSharedUtils\Exceptions;
  * Thrown when AttachmentService rejects an upload because the malware scan
  * matched one or more rules. Maps to HTTP 422 via BaseHttpRequestException so
  * the client sees a clean validation-style rejection. The matched rule ids are
- * deliberately kept out of the client-facing message (they would disclose
- * detection logic) and travel in the Sentry/logging extra instead.
+ * deliberately kept out of the client-facing response (they would disclose
+ * detection logic) and travel in log-only Sentry/logging context instead.
  */
 class MalwareDetectedException extends BaseHttpRequestException
 {
@@ -27,7 +27,8 @@ class MalwareDetectedException extends BaseHttpRequestException
             422,
             null,
             tags: ['malware_scan' => 'detected'],
-            extra: ['file_name' => $filename, 'matched_rules' => $matchedRules],
+            extra: ['file_name' => $filename],
+            logExtra: ['matched_rules' => $matchedRules],
         );
     }
 

--- a/src/Exceptions/MalwareScanFailedException.php
+++ b/src/Exceptions/MalwareScanFailedException.php
@@ -13,7 +13,7 @@ use Throwable;
  * can retry once the scanner is healthy.
  *
  * Keep messages free of local paths and engine output; diagnostic detail
- * belongs in $extra where it reaches logs/Sentry but not the client.
+ * belongs in log-only context where it reaches logs/Sentry but not the client.
  */
 class MalwareScanFailedException extends BaseHttpRequestException
 {
@@ -24,7 +24,7 @@ class MalwareScanFailedException extends BaseHttpRequestException
             503,
             $previous,
             tags: ['malware_scan' => 'failed'],
-            extra: $extra,
+            logExtra: $extra,
         );
     }
 }

--- a/src/Exceptions/MalwareScanFailedException.php
+++ b/src/Exceptions/MalwareScanFailedException.php
@@ -17,6 +17,10 @@ use Throwable;
  */
 class MalwareScanFailedException extends BaseHttpRequestException
 {
+    /**
+     * @param  array<string, mixed>  $extra  Diagnostic context routed to log-only storage. The
+     *                                       parameter name is retained for named-argument compatibility.
+     */
     public function __construct(string $message, ?Throwable $previous = null, array $extra = [])
     {
         parent::__construct(

--- a/src/Logging/ErrorLogger.php
+++ b/src/Logging/ErrorLogger.php
@@ -2,8 +2,15 @@
 
 namespace NuiMarkets\LaravelSharedUtils\Logging;
 
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
 use NuiMarkets\LaravelSharedUtils\Exceptions\BaseHttpRequestException;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * Centralized error logging with consistent formatting across services.
@@ -20,8 +27,9 @@ class ErrorLogger
      * Log an exception with standard context.
      *
      * When the exception is a BaseHttpRequestException (e.g. RemoteServiceException),
-     * any structured `extra` data (api.service, api.status, etc.) is automatically
-     * merged into the log context. This means callers can do:
+     * any structured client-safe or log-only data (api.service, api.status,
+     * etc.) is automatically merged into the log context. This means callers
+     * can do:
      *
      *     ErrorLogger::logException($e, ['address_id' => $id]);
      *
@@ -42,8 +50,8 @@ class ErrorLogger
 
         // Extract structured context from BaseHttpRequestException (e.g. RemoteServiceException)
         // This pulls in api.service, api.endpoint, api.status, api.errors etc.
-        if ($e instanceof BaseHttpRequestException && ! empty($e->getExtra())) {
-            $errorContext = array_merge($errorContext, $e->getExtra());
+        if ($e instanceof BaseHttpRequestException && ! empty($e->getLogContext())) {
+            $errorContext = array_merge($errorContext, $e->getLogContext());
         }
 
         // Add stack trace for non-production environments
@@ -111,11 +119,11 @@ class ErrorLogger
         ];
 
         // Handle different response types
-        if ($response instanceof \Illuminate\Http\Client\Response) {
+        if ($response instanceof Response) {
             $apiContext[LogFields::API_STATUS] = $response->status();
             $apiContext['response_body'] = static::truncateResponseBody($response->body());
             $apiContext['response_headers'] = $response->headers();
-        } elseif ($response instanceof \Psr\Http\Message\ResponseInterface) {
+        } elseif ($response instanceof ResponseInterface) {
             $apiContext[LogFields::API_STATUS] = $response->getStatusCode();
             $apiContext['response_body'] = static::truncateResponseBody((string) $response->getBody());
         } elseif (is_array($response)) {
@@ -172,13 +180,13 @@ class ErrorLogger
     protected static function getLogLevel(\Throwable $e): string
     {
         // Authentication/Authorization exceptions
-        if ($e instanceof \Illuminate\Auth\AuthenticationException ||
-            $e instanceof \Illuminate\Auth\Access\AuthorizationException) {
+        if ($e instanceof AuthenticationException ||
+            $e instanceof AuthorizationException) {
             return 'warning';
         }
 
         // Client errors (4xx) should be warnings
-        if ($e instanceof \Symfony\Component\HttpKernel\Exception\HttpException) {
+        if ($e instanceof HttpException) {
             $statusCode = $e->getStatusCode();
             if ($statusCode >= 400 && $statusCode < 500) {
                 return $statusCode === 404 ? 'info' : 'warning';
@@ -186,12 +194,12 @@ class ErrorLogger
         }
 
         // Validation exceptions are info level
-        if ($e instanceof \Illuminate\Validation\ValidationException) {
+        if ($e instanceof ValidationException) {
             return 'info';
         }
 
         // Database connection errors are critical
-        if ($e instanceof \Illuminate\Database\QueryException) {
+        if ($e instanceof QueryException) {
             if (str_contains($e->getMessage(), 'Connection refused') ||
                 str_contains($e->getMessage(), 'SQLSTATE[HY000]')) {
                 return 'critical';

--- a/src/Logging/SentryHandler.php
+++ b/src/Logging/SentryHandler.php
@@ -40,8 +40,8 @@ class SentryHandler extends AbstractProcessingHandler
                         $scope->setTags($context['exception']->getTags());
                     }
 
-                    if (! empty($context['exception']->getExtra())) {
-                        $scope->setExtras($context['exception']->getExtra());
+                    if (! empty($context['exception']->getLogContext())) {
+                        $scope->setExtras($context['exception']->getLogContext());
                     }
                 }
 

--- a/src/Services/AttachmentService.php
+++ b/src/Services/AttachmentService.php
@@ -591,7 +591,7 @@ class AttachmentService
             'file_name' => $filenames[0] ?? null,
             'file_names' => $filenames,
             'error' => $e->getMessage(),
-            'extra' => $e->getExtra(),
+            'extra' => $e->getLogContext(),
             'exception' => $e,
         ];
 

--- a/src/Services/YaraXScanner.php
+++ b/src/Services/YaraXScanner.php
@@ -35,7 +35,7 @@ use Throwable;
 class YaraXScanner implements MalwareScanner
 {
     /**
-     * Cap on engine stdout/stderr captured into exception extra, so a
+     * Cap on engine stdout/stderr captured into exception log context, so a
      * misbehaving scanner can't flood logs or Sentry payloads.
      */
     private const OUTPUT_CAP = 1000;

--- a/tests/Feature/Exceptions/BaseErrorHandlerTest.php
+++ b/tests/Feature/Exceptions/BaseErrorHandlerTest.php
@@ -126,8 +126,9 @@ class BaseErrorHandlerTest extends TestCase
         );
     }
 
-    public function test_malware_failure_diagnostics_stay_out_of_debug_response()
+    public function test_malware_failure_diagnostics_stay_out_of_debug_response_but_reach_logs()
     {
+        Log::spy();
         $this->app->instance('env', 'production');
         config()->set('app.debug', true);
         $request = Request::create('/test', 'POST');
@@ -137,6 +138,7 @@ class BaseErrorHandlerTest extends TestCase
             'binary' => '/usr/local/bin/yr',
             'stderr' => 'private engine output',
         ]);
+        $this->handler->report($exception);
         $response = $this->handler->render($request, $exception);
 
         $this->assertEquals(503, $response->getStatusCode());
@@ -144,6 +146,15 @@ class BaseErrorHandlerTest extends TestCase
         $this->assertStringNotContainsString('/etc/yara/private-rules.yarc', $content);
         $this->assertStringNotContainsString('/usr/local/bin/yr', $content);
         $this->assertStringNotContainsString('private engine output', $content);
+
+        Log::shouldHaveReceived('error')->once()->with(
+            'MalwareScanFailedException',
+            \Mockery::on(function ($context) {
+                return $context['rules_path'] === '/etc/yara/private-rules.yarc' &&
+                       $context['binary'] === '/usr/local/bin/yr' &&
+                       $context['stderr'] === 'private engine output';
+            })
+        );
     }
 
     public function test_remote_service_exception_with_tags_and_extra()

--- a/tests/Feature/Exceptions/BaseErrorHandlerTest.php
+++ b/tests/Feature/Exceptions/BaseErrorHandlerTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use NuiMarkets\LaravelSharedUtils\Exceptions\BaseErrorHandler;
 use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareDetectedException;
+use NuiMarkets\LaravelSharedUtils\Exceptions\MalwareScanFailedException;
 use NuiMarkets\LaravelSharedUtils\Exceptions\RemoteServiceException;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -84,9 +85,8 @@ class BaseErrorHandlerTest extends TestCase
 
     public function test_malware_detected_response_does_not_leak_detection_internals()
     {
-        // Rule ids, engine output, and paths live in the exception extra for
-        // logs/Sentry; the client response must never include them outside
-        // debug mode.
+        // Rule ids, engine output, and paths live in log-only context; the
+        // client response must never include them.
         config()->set('app.debug', false);
         $request = Request::create('/test', 'POST');
 
@@ -99,6 +99,51 @@ class BaseErrorHandlerTest extends TestCase
         $this->assertStringContainsString('invoice.pdf', $content);
         $this->assertStringNotContainsString('Secret_Detection_Rule', $content);
         $this->assertStringNotContainsString('matched_rules', $content);
+    }
+
+    public function test_malware_diagnostics_stay_out_of_debug_response_but_reach_logs()
+    {
+        Log::spy();
+        $this->app->instance('env', 'production');
+        config()->set('app.debug', true);
+        $request = Request::create('/test', 'POST');
+
+        $exception = new MalwareDetectedException('invoice.pdf', ['Secret_Detection_Rule']);
+        $response = $this->handler->render($request, $exception);
+
+        $this->assertEquals(422, $response->getStatusCode());
+        $content = $response->getContent();
+        $this->assertStringContainsString('invoice.pdf', $content);
+        $this->assertStringNotContainsString('Secret_Detection_Rule', $content);
+        $this->assertStringNotContainsString('matched_rules', $content);
+
+        Log::shouldHaveReceived('info')->once()->with(
+            'MalwareDetectedException',
+            \Mockery::on(function ($context) {
+                return $context['file_name'] === 'invoice.pdf' &&
+                       $context['matched_rules'] === ['Secret_Detection_Rule'];
+            })
+        );
+    }
+
+    public function test_malware_failure_diagnostics_stay_out_of_debug_response()
+    {
+        $this->app->instance('env', 'production');
+        config()->set('app.debug', true);
+        $request = Request::create('/test', 'POST');
+
+        $exception = new MalwareScanFailedException('Malware scan failed.', extra: [
+            'rules_path' => '/etc/yara/private-rules.yarc',
+            'binary' => '/usr/local/bin/yr',
+            'stderr' => 'private engine output',
+        ]);
+        $response = $this->handler->render($request, $exception);
+
+        $this->assertEquals(503, $response->getStatusCode());
+        $content = $response->getContent();
+        $this->assertStringNotContainsString('/etc/yara/private-rules.yarc', $content);
+        $this->assertStringNotContainsString('/usr/local/bin/yr', $content);
+        $this->assertStringNotContainsString('private engine output', $content);
     }
 
     public function test_remote_service_exception_with_tags_and_extra()

--- a/tests/Unit/Exceptions/MalwareExceptionsTest.php
+++ b/tests/Unit/Exceptions/MalwareExceptionsTest.php
@@ -23,10 +23,15 @@ class MalwareExceptionsTest extends TestCase
         $e = new MalwareDetectedException('invoice.pdf', ['Secret_Detection_Rule']);
 
         // Filename helps the client identify the offending upload; rule ids
-        // would disclose detection logic, so they stay in extra (logs/Sentry).
+        // would disclose detection logic, so they stay in log-only context.
         $this->assertStringContainsString('invoice.pdf', $e->getMessage());
         $this->assertStringNotContainsString('Secret_Detection_Rule', $e->getMessage());
-        $this->assertSame(['Secret_Detection_Rule'], $e->getExtra()['matched_rules']);
+        $this->assertSame(['file_name' => 'invoice.pdf'], $e->getExtra());
+        $this->assertSame(['matched_rules' => ['Secret_Detection_Rule']], $e->getLogExtra());
+        $this->assertSame([
+            'file_name' => 'invoice.pdf',
+            'matched_rules' => ['Secret_Detection_Rule'],
+        ], $e->getLogContext());
         $this->assertSame(['malware_scan' => 'detected'], $e->getTags());
     }
 
@@ -37,7 +42,9 @@ class MalwareExceptionsTest extends TestCase
 
         $this->assertInstanceOf(BaseHttpRequestException::class, $e);
         $this->assertSame(503, $e->getStatusCode());
-        $this->assertSame(['timeout_seconds' => 10], $e->getExtra());
+        $this->assertSame([], $e->getExtra());
+        $this->assertSame(['timeout_seconds' => 10], $e->getLogExtra());
+        $this->assertSame(['timeout_seconds' => 10], $e->getLogContext());
         $this->assertSame(['malware_scan' => 'failed'], $e->getTags());
         $this->assertSame($previous, $e->getPrevious());
     }

--- a/tests/Unit/Exceptions/MalwareExceptionsTest.php
+++ b/tests/Unit/Exceptions/MalwareExceptionsTest.php
@@ -9,6 +9,24 @@ use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 
 class MalwareExceptionsTest extends TestCase
 {
+    public function test_base_exception_log_only_context_can_be_replaced_fluently()
+    {
+        $e = new BaseHttpRequestException(
+            'Request failed.',
+            extra: ['request_id' => 'request-123'],
+            logExtra: ['stderr' => 'first failure'],
+        );
+
+        $result = $e->withLogExtra(['stderr' => 'replacement failure']);
+
+        $this->assertSame($e, $result);
+        $this->assertSame(['stderr' => 'replacement failure'], $e->getLogExtra());
+        $this->assertSame([
+            'request_id' => 'request-123',
+            'stderr' => 'replacement failure',
+        ], $e->getLogContext());
+    }
+
     public function test_malware_detected_maps_to_422()
     {
         $e = new MalwareDetectedException('invoice.pdf', ['Rule_A', 'Rule_B']);

--- a/tests/Unit/Logging/ErrorLoggerTest.php
+++ b/tests/Unit/Logging/ErrorLoggerTest.php
@@ -2,10 +2,13 @@
 
 namespace NuiMarkets\LaravelSharedUtils\Tests\Unit\Logging;
 
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
+use NuiMarkets\LaravelSharedUtils\Exceptions\BaseHttpRequestException;
 use NuiMarkets\LaravelSharedUtils\Logging\ErrorLogger;
 use NuiMarkets\LaravelSharedUtils\Tests\TestCase;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -88,6 +91,26 @@ class ErrorLoggerTest extends TestCase
         );
     }
 
+    public function test_log_exception_includes_log_only_context()
+    {
+        $exception = new BaseHttpRequestException(
+            'Scanner failed',
+            503,
+            extra: ['request_id' => 'visible-context'],
+            logExtra: ['scanner_binary' => '/usr/local/bin/yr'],
+        );
+
+        ErrorLogger::logException($exception);
+
+        Log::shouldHaveReceived('error')->once()->with(
+            'Scanner failed',
+            \Mockery::on(function ($context) {
+                return $context['request_id'] === 'visible-context' &&
+                       $context['scanner_binary'] === '/usr/local/bin/yr';
+            })
+        );
+    }
+
     public function test_validation_exception_logs_as_info()
     {
         // Ensure Log facade is properly spied on
@@ -96,8 +119,8 @@ class ErrorLoggerTest extends TestCase
             \Mockery::type('array')
         );
 
-        $validator = \Mockery::mock(\Illuminate\Contracts\Validation\Validator::class);
-        $validator->shouldReceive('errors')->andReturn(new \Illuminate\Support\MessageBag(['field' => ['error']]));
+        $validator = \Mockery::mock(Validator::class);
+        $validator->shouldReceive('errors')->andReturn(new MessageBag(['field' => ['error']]));
 
         $exception = new ValidationException($validator);
 

--- a/tests/Unit/Services/YaraXScannerTest.php
+++ b/tests/Unit/Services/YaraXScannerTest.php
@@ -445,7 +445,7 @@ class YaraXScannerTest extends TestCase
             $this->scanner($binary)->scan([$this->targetFile]);
             $this->fail('Expected MalwareScanFailedException');
         } catch (MalwareScanFailedException $e) {
-            $this->assertLessThanOrEqual(1000, strlen($e->getExtra()['stderr']));
+            $this->assertLessThanOrEqual(1000, strlen($e->getLogExtra()['stderr']));
         }
     }
 

--- a/tests/Unit/Support/ProfilingTraitTest.php
+++ b/tests/Unit/Support/ProfilingTraitTest.php
@@ -172,9 +172,10 @@ class ProfilingTraitTest extends TestCase
                 return count($breakdown) === 2 &&
                        $breakdown[0]['method'] === 'get' &&
                        $breakdown[1]['method'] === 'post' &&
-                       isset($breakdown[0]['seconds']) &&
-                       isset($breakdown[1]['seconds']) &&
-                       $breakdown[1]['seconds'] > $breakdown[0]['seconds']; // post took longer
+                       is_float($breakdown[0]['seconds']) &&
+                       is_float($breakdown[1]['seconds']) &&
+                       $breakdown[0]['seconds'] >= 0 &&
+                       $breakdown[1]['seconds'] >= 0;
             }));
 
         $this->testClass->publicLogTimings();


### PR DESCRIPTION
## Summary

- add log-only exception context for diagnostics that must reach logs and Sentry
- move malware rule matches and scanner failure details out of debug HTTP responses
- preserve merged context across the base handler, centralized logger, Sentry handler, and attachment scan policies
- remove a scheduler-sensitive assertion from the profiling test

## Testing

- composer test-all (673 tests, 2,093 assertions; 23 skipped, existing deprecations/notices)
- targeted Pint check on all modified PHP files
- targeted exception, logger, and scanner tests

## Review

- approved by GLM-5.2 and DeepSeek V4 Flash agentic reviewers
- follow-up coverage added for 503 error logging and the fluent log-only context API